### PR TITLE
bug fix in valuesets endpoint

### DIFF
--- a/src/hs_ontology_api/utils/neo4j_logic.py
+++ b/src/hs_ontology_api/utils/neo4j_logic.py
@@ -392,7 +392,6 @@ def valueset_get_logic(neo4j_instance, parent_sab: str, parent_code: str, child_
     query = query + 'WHERE r.CUI = conceptChildCUI '
     query = query + 'RETURN termChild.name AS term, codeChild.CODE as code,codeChild.SAB as sab'
 
-    print(query)
     # Execute Cypher query and return result.
     with neo4j_instance.driver.session() as session:
         recds: neo4j.Result = session.run(query)

--- a/src/hs_ontology_api/utils/neo4j_logic.py
+++ b/src/hs_ontology_api/utils/neo4j_logic.py
@@ -361,10 +361,13 @@ def valueset_get_logic(neo4j_instance, parent_sab: str, parent_code: str, child_
 
     query: str = 'CALL'
     query = query + '{'
-    query = query + 'MATCH (codeChild:Code)<-[:CODE]-(conceptChild:Concept)-[:isa]->(conceptParent:Concept)-[' \
+    # JAS Nov 2023 limit SABs for isa relationship to specified child values
+    query = query + 'MATCH (codeChild:Code)<-[:CODE]-(conceptChild:Concept)-[r:isa]->(conceptParent:Concept)-[' \
                     ':CODE]->(codeParent:Code) '
     query = query + ' WHERE codeParent.SAB=\'' + parent_sab + '\' AND codeParent.CODE=\'' + parent_code + '\''
     query = query + ' AND codeChild.SAB IN ' + sab_in
+    # JAS Nov 2023 limit SABs for isa relationship to specified child values
+    query = query + ' AND r.SAB IN ' + sab_in
     query = query + ' RETURN conceptChild.CUI AS conceptChildCUI, min(' + sab_case + ') AS minSAB'
     query = query + ' ORDER BY conceptChildCUI'
     query = query + '}'
@@ -389,6 +392,7 @@ def valueset_get_logic(neo4j_instance, parent_sab: str, parent_code: str, child_
     query = query + 'WHERE r.CUI = conceptChildCUI '
     query = query + 'RETURN termChild.name AS term, codeChild.CODE as code,codeChild.SAB as sab'
 
+    print(query)
     # Execute Cypher query and return result.
     with neo4j_instance.driver.session() as session:
         recds: neo4j.Result = session.run(query)


### PR DESCRIPTION
See explanation: https://github.com/x-atlas-consortia/hs-ontology-api/issues/57

This change is part of a two-part solution to the bug. 

The second part is the deployment of the UBKG neo4j in HMSN14NOV2023.Zip, located in Globus at
https://g-24f5cc.09193a.5898.dn.glob.us/projects/data-distillery/Validated/Distribution/HMSN14NOV2023.zip.

The two parts can be deployed independently; however, with the new UBKG, the valueset call that returns entities for HUBMAP (e.g., <url>/valueset?parent_sab=HUBMAP&parent_code=C000012&child_sabs=HUBMAP) will also work as expected. The current metadata validation code in HUBMAP uses hard-coded values instead of a call to the UBKG, so this change should not affect that feature.