### PR TITLE
added informative error handling to field-entities endpoint

### DIFF
--- a/src/hs_ontology_api/routes/fieldentities/fieldentities_controller.py
+++ b/src/hs_ontology_api/routes/fieldentities/fieldentities_controller.py
@@ -2,7 +2,8 @@
 # JAS January 2024
 from flask import Blueprint, jsonify, current_app, request, make_response
 from hs_ontology_api.utils.neo4j_logic import field_entities_get_logic
-from hs_ontology_api.utils.http_error_string import get_404_error_string,validate_query_parameter_names
+from hs_ontology_api.utils.http_error_string import get_404_error_string,validate_query_parameter_names, \
+    validate_parameter_value_in_enum
 
 
 field_entities_blueprint = Blueprint('field-entities', __name__, url_prefix='/field-entities')
@@ -25,8 +26,10 @@ def field_entities_get(name=None):
     source = request.args.get('source')
     if source is not None:
         source = source.upper()
-        if source not in ['HMFIELD', 'HUBMAP']:
-            return make_response(f"Invalid value for source parameter: '{source}'", 400)
+        val_enum = ['HMFIELD', 'HUBMAP']
+        err = validate_parameter_value_in_enum(param_name='source', param_value=source, enum_list=val_enum)
+        if err != 'ok':
+            return make_response(err, 400)
 
 
     entity = request.args.get('entity')


### PR DESCRIPTION
During testing in DEV, I discovered that the field-entities endpoint did not have the newer, more informative error messages for the case of the source parameter value not being in an enum.