### PR TITLE
bug fix for parameter validation in field-types endpoint

### DIFF
--- a/src/hs_ontology_api/routes/fieldtypes/fieldtypes_controller.py
+++ b/src/hs_ontology_api/routes/fieldtypes/fieldtypes_controller.py
@@ -20,11 +20,10 @@ def field_types_get(name=None):
     if err != 'ok':
         return make_response(err, 400)
 
-    val_enum = ['HMFIELD', 'XSD']
-
     # Validate mapping source.
     mapping_source = request.args.get('mapping_source')
     if mapping_source is not None:
+        val_enum = ['HMFIELD', 'CEDAR']
         mapping_source = mapping_source.upper()
         err = validate_parameter_value_in_enum(param_name='mapping_source', param_value=mapping_source,
                                                enum_list=val_enum)
@@ -34,6 +33,7 @@ def field_types_get(name=None):
     # Validate type source.
     type_source = request.args.get('type_source')
     if type_source is not None:
+        val_enum = ['HMFIELD', 'XSD']
         type_source = type_source.upper()
         err = validate_parameter_value_in_enum(param_name='type_source', param_value=type_source,
                                                enum_list=val_enum)


### PR DESCRIPTION
The field-types endpoint can evaluate two parameters against whether values are in enums. The code was using the same enum for both, when there are actually two:
mapping_source must be one of {HMFIELD,CEDAR}
type_source must be one of {HMFIELD,XSD}

The fix correctly evaluates per enum.