### PR TITLE
Tjmadonna/40 remove werkzeug

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,4 @@
 Flask==3.0.3
-# Flask depends on Werkzeug...
-Werkzeug==3.0.3
 
 #git+https://github.com/x-atlas-consortia/ubkg-api.git@dev-integrate
 ubkg-api==2.2.2


### PR DESCRIPTION
Changes
- Removed explicit werkzeug version in `requirements.txt` [devops #40](https://github.com/sennetconsortium/devops/issues/40)