### PR TITLE
Refactoring of endpoints related to celltypes and genes

### DIFF
--- a/hs-ontology-api-spec.yaml
+++ b/hs-ontology-api-spec.yaml
@@ -691,7 +691,7 @@ paths:
           description: a comma-delimited list of integer Cell Ontology IDs. Integers without leading zeroes will be padded to 7 digits--e.g., 235 will become 0000235.
           schema:
             type: string
-            example: 2138,236
+            example: 2138,0000236,fibroblast
       responses:
         '200':
           description: reference information on the cell types
@@ -720,13 +720,13 @@ paths:
       operationId: celltypes_detail_get
       summary: Return detailed information on a cell type specified by an identifier (Cell Ontology ID), including marker associations (via the Human Resource Atlas) and annotation mappings (from Azimuth, STELLAR, etc.)
       parameters:
-        - name: id
+        - name: ids
           in: path
           required: true
-          description: Cell Ontology ID
+          description: a comma-delimited list of integer Cell Ontology IDs. Integers without leading zeroes will be padded to 7 digits--e.g., 235 will become 0000235.
           schema:
             type: string
-            example: 0002138
+            example: 2138,0000236,fibroblast
       responses:
         '200':
           description: detailed information on the cell type specified by a Cell Ontology identifier.

--- a/hs-ontology-api-spec.yaml
+++ b/hs-ontology-api-spec.yaml
@@ -645,10 +645,45 @@ paths:
           description: Unexpected error
       tags:
         - biological entities
-  /celltypes/{id}:
+  /celltypes/{ids}:
     get:
       operationId: celltypes_get
-      summary: Return detailed information on a cell type specified by an identifier (Cell Ontology ID).
+      summary: Return information on a set of cell types specified by a list of Cell Ontology IDs
+      parameters:
+        - name: ids
+          in: path
+          required: true
+          description: a comma-delimited list of integer Cell Ontology IDs. Integers without leading zeroes will be padded to 7 digits--e.g., 235 will become 0000235.
+          schema:
+            type: string
+            example: 2138,236
+      responses:
+        '200':
+          description: reference information on the cell types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CellTypeResponse'
+        '303':
+          description: The response size exceeds a limit set by the server. The response content is stored in a file in a AWS S3 bucket. The returned response includes a URL that can be used to download the stored file.
+        '400':
+          description: Missing parameter; invalid parameter value
+        '403':
+          description: The response size exceeds a limit set by the server.
+        '404':
+          description: No information for cell type with Cell Ontology identifiers *id*.
+        '504':
+          description: The query run time exceeded the specified timeout.
+        '5XX':
+          description: Unexpected error
+      tags:
+        - biological entities
+  /celltypes/{id}/detail:
+    get:
+      operationId: celltypes_detail_get
+      summary: Return detailed information on a cell type specified by an identifier (Cell Ontology ID), including marker associations (via the Human Resource Atlas) and annotation mappings (from Azimuth, STELLAR, etc.)
       parameters:
         - name: id
           in: path
@@ -1753,6 +1788,26 @@ components:
                 type: string
                 description: SAB of the cell type annotation
                 example: AZ
+    CellTypeResponse:
+      type: object
+      description: Reference information on a cell type requested by the celltypes endpoint
+      properties:
+        cell_type:
+          type: object
+          description: cell type identifiers
+          properties:
+            id:
+              type: string
+              description: Cell Ontology code
+              example: CL:0002138
+            name:
+              type: string
+              description: Preferred term for the cell type from Cell Ontology
+              example: endothelial cell of lymphatic vessel
+            definition:
+              type: string
+              description: Definition of the cell type from Cell Ontology
+              example: A endothelial cell of a lymphatic vessel. The border of…
     FieldDescriptionsResponse:
       type: object
       description: Descriptions for ingest metadata fields

--- a/hs-ontology-api-spec.yaml
+++ b/hs-ontology-api-spec.yaml
@@ -715,7 +715,7 @@ paths:
           description: Unexpected error
       tags:
         - biological entities
-  /celltypes/{id}/detail:
+  /celltypes/{ids}/detail:
     get:
       operationId: celltypes_detail_get
       summary: Return detailed information on a cell type specified by an identifier (Cell Ontology ID), including marker associations (via the Human Resource Atlas) and annotation mappings (from Azimuth, STELLAR, etc.)

--- a/hs-ontology-api-spec.yaml
+++ b/hs-ontology-api-spec.yaml
@@ -478,7 +478,42 @@ paths:
   /genes/{id}:
     get:
       operationId: genes_get
-      summary: Return detailed information on a gene specified by a HGNC identifier.
+      summary: Return reference information on a set of genes specified by a HGNC identifiers
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Comma-delimited set of HGNC identifiers. An identifier can be an approved ID (e.g., 7178); approved symbol (e.g., MMRN1); alias (e.g., EMILIN4 for MMRN1); previous symbol (e.g., MMRN for MMRN1); previous alias; or a name string (approved, previous, alias--e.g., "multimerin 1").
+          schema:
+            type: string
+            example: MMRN1,BRCA1
+      responses:
+        '200':
+          description: reference information on the genes specified by the HGNC identifiers.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GeneResponse'
+        '303':
+          description: The response size exceeds a limit set by the server. The response content is stored in a file in a AWS S3 bucket. The returned response includes a URL that can be used to download the stored file.
+        '400':
+          description: Missing parameter; invalid parameter value
+        '403':
+          description: The response size exceeds a limit set by the server.
+        '404':
+          description: No information for gene with HGNC identifier *id*.
+        '504':
+          description: The query run time exceeded the specified timeout.
+        '5XX':
+          description: Unexpected error
+      tags:
+        - biological entities
+  /genes/{id}/detail:
+    get:
+      operationId: genes_detail_get
+      summary: Return detailed information on a gene specified by a HGNC identifier, including mappings from annotations
       parameters:
         - name: id
           in: path
@@ -1451,6 +1486,68 @@ components:
               type: number
               description: Calculated count of items. If starts_with is non-null, the count is that of the genes with approved HGNC symbols that start with the value of starts_with.
               example: 500
+    GeneResponse:
+      type: object
+      description: Refre ce information on a gene requested by the gene endpoint
+      properties:
+        alias_names:
+          type: array
+          description: HGNC alias names
+          items:
+            type: string
+          example: [ glycoprotein Ia* ]
+        alias_symbols:
+          type: array
+          description: HGNC alias symbols
+          items:
+            type: string
+          example: [ GPIa*,EMILIN4,ECM ]
+        approved_name:
+          type: string
+          description: HGNC approved name
+          example: multimerin 1
+        approved_symbol:
+          type: string
+          description: HGNC approved symbol
+          example: MMRN1
+        hgnc_id:
+          type: number
+          description: numeric HGNC ID for the gene
+          example: 60
+        previous_names:
+          type: array
+          description: previous names for the gene in HGNC
+          items:
+            type: string
+          example: [ multimerin ]
+        previous_symbols:
+          type: array
+          description: previous symbols for the gene in HGNC
+          items:
+            type: string
+            example: [ MMRN ]
+        references:
+          type: array
+          description: Reference for the gene between HGNC and other vocabularies. References can be either a cross-reference (e.g., between HGNC ID and NCBI Entrez ID) or from a known relationship (e.g., gene-protein relationships between a gene in HGNC and a protein in UniProtKB).
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: ID (code) for the reference in the source
+                example: 22915
+              source:
+                type: string
+                description: source vocabulary for the reference
+                example: entrez
+              url:
+                type: string
+                description: URL to reference site
+                example: https://www.ncbi.nlm.nih.gov/gene/22915
+        summary:
+          type: string
+          description: RefSeq summary of the gene
+          example: Multimerin is a massive, soluble protein found in....
     GeneDetailResponse: # JAS Sept 2023
       type: object
       description: Detailed information on a gene requested by the gene endpoint

--- a/src/hs_ontology_api/cypher/celltype.cypher
+++ b/src/hs_ontology_api/cypher/celltype.cypher
@@ -1,0 +1,29 @@
+// OCTOBER 2025
+// Return reference information (terms, definitions) on cell types, based on a input list of CL codes or terms.
+// Used by the celltypes/<id> endpoint.
+
+CALL
+// Get CUIs of concepts for cell types that match the criteria.
+
+{
+
+// Criteria: Cell Ontology code
+//WITH ['0002138','0000236'] AS ids
+//WITH [''] AS ids
+
+// The calling function in neo4j_logic.py will replace $ids.
+WITH [$ids] AS ids
+
+// Because PATO and UBERON are ingested prior to CL, some CL codes will associate with multiple concepts.
+// Use the concept that is associated with the code during the CL ingestion, which can be identified by the use of a
+// preferred term (term of relationship type PT).
+OPTIONAL MATCH (dCL:Definition {SAB:'CL'})<-[:DEF]-(pCL:Concept)-[:CODE]->(cCL:Code{SAB:'CL'})-[r:PT]->(tCL:Term)
+WHERE r.CUI = pCL.CUI
+AND CASE WHEN ids[0]<>'' THEN ANY(id in ids WHERE cCL.CodeID='CL:'+id) ELSE 1=1 END
+RETURN DISTINCT pCL.CUI AS CLCUI, cCL.CodeID as CLID, tCL.name AS name, COLLECT(dCL.DEF)[0] AS definition
+}
+WITH CLID, name, definition
+WHERE CLID IS NOT NULL
+
+WITH COLLECT({cell_type:{id:CLID,name:name,definition:definition}}) AS celltype
+RETURN celltype

--- a/src/hs_ontology_api/cypher/celltype.cypher
+++ b/src/hs_ontology_api/cypher/celltype.cypher
@@ -2,6 +2,8 @@
 // Return reference information (terms, definitions) on cell types, based on a input list of CL codes or search.
 // Used by the celltypes/<id> endpoint.
 
+// Returns as JSON.
+
 CALL
 // Get CUIs of concepts for cell types that match the criteria.
 

--- a/src/hs_ontology_api/cypher/celltype.cypher
+++ b/src/hs_ontology_api/cypher/celltype.cypher
@@ -1,5 +1,5 @@
 // OCTOBER 2025
-// Return reference information (terms, definitions) on cell types, based on a input list of CL codes or terms.
+// Return reference information (terms, definitions) on cell types, based on a input list of CL codes or search.
 // Used by the celltypes/<id> endpoint.
 
 CALL
@@ -14,16 +14,30 @@ CALL
 // The calling function in neo4j_logic.py will replace $ids.
 WITH [$ids] AS ids
 
-// Because PATO and UBERON are ingested prior to CL, some CL codes will associate with multiple concepts.
-// Use the concept that is associated with the code during the CL ingestion, which can be identified by the use of a
-// preferred term (term of relationship type PT).
+// 1. Because PATO and UBERON are ingested prior to CL, some CL codes may associate with multiple concepts.
+//    Use the concept that is associated with the code during the CL ingestion, which can be identified by the use of a
+//    preferred term (term of relationship type PT).
+// 2. If the id is an integer, assume a search on CL ID; otherwise, assume a search on a term.
+// 3. Because the definition of a code is associated with the code's concept, there will generally be duplicate definitions per code.
+//    Take the first definition in the list.
 OPTIONAL MATCH (dCL:Definition {SAB:'CL'})<-[:DEF]-(pCL:Concept)-[:CODE]->(cCL:Code{SAB:'CL'})-[r:PT]->(tCL:Term)
 WHERE r.CUI = pCL.CUI
-AND CASE WHEN ids[0]<>'' THEN ANY(id in ids WHERE cCL.CodeID='CL:'+id) ELSE 1=1 END
+AND (
+  ids[0] <> '' AND
+  ANY(id IN ids WHERE
+    CASE
+      WHEN id =~ '^\d+$' THEN
+        cCL.CodeID = 'CL:' + id
+      ELSE
+       tCL.name CONTAINS id
+    END
+  )
+  OR ids[0] = ''
+)
 RETURN DISTINCT pCL.CUI AS CLCUI, cCL.CodeID as CLID, tCL.name AS name, COLLECT(dCL.DEF)[0] AS definition
 }
+// Filter out null codes.
 WITH CLID, name, definition
 WHERE CLID IS NOT NULL
-
 WITH COLLECT({cell_type:{id:CLID,name:name,definition:definition}}) AS celltype
 RETURN celltype

--- a/src/hs_ontology_api/cypher/celltypedetail.cypher
+++ b/src/hs_ontology_api/cypher/celltypedetail.cypher
@@ -1,4 +1,5 @@
 // Return detailed information on cell types, based on a input list of CL codes.
+// Used by the celltypes/<id>/detail route.
 
 CALL
 // Get CUIs of concepts for cell types that match the criteria.

--- a/src/hs_ontology_api/cypher/celltypedetail.cypher
+++ b/src/hs_ontology_api/cypher/celltypedetail.cypher
@@ -88,14 +88,12 @@ CALL
 CALL
 {
 	WITH CLCUI,CLID,name,definition,mapID
-   	OPTIONAL MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:located_in]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB]->(tUB:Term)
+   	OPTIONAL MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:located_in]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB:PT_UBERON_BASE]->(tUB:Term)
     WHERE rMapUB.SAB IN ['AZ','STELLAR','DCT']
     AND rUB.CUI=pUB.CUI
     AND cMap.CodeID=mapID
     AND cUB.SAB='UBERON'
-    AND TYPE(rUB) STARTS WITH 'PT'
-    //RETURN cUB.CodeID+'|'+ tUB.name + '|' + rMapUB.SAB as UBERONID
-    RETURN cUB.CodeID AS UBCode, tUB.name AS UBName, rMapUB.SAB AS UBAnnotation
+    RETURN cUB.CodeID AS UBCode, tUB.name AS UBName, rMapUB.SAB AS UBAnnotation, 'UBERON' AS source
 
     UNION
 
@@ -105,13 +103,12 @@ CALL
     AND rUB.CUI=pUB.CUI
     AND cMap.CodeID=mapID
     AND cUB.SAB='PAZ'
-    //RETURN cUB.CodeID+'|'+ tUB.name + '|' + 'PAZ' as UBERONID
-    RETURN cUB.CodeID AS UBCode, tUB.name AS UBName, 'PAZ' AS UBAnnotation
+    RETURN cUB.CodeID AS UBCode, tUB.name AS UBName, 'PAZ' AS UBAnnotation, 'PAZ' as source
 
 }
 
 // Collect and order organs by annotation type.
-WITH CLID,name,definition,biomarkers, COLLECT({id:UBCode,name:UBName,source:'UBERON',annotation:UBAnnotation}) AS organ_list
+WITH CLID,name,definition,biomarkers, COLLECT(DISTINCT{id:UBCode,name:UBName,source:source,annotation:UBAnnotation}) AS organ_list
 WHERE CLID IS NOT NULL
 UNWIND organ_list AS organ
 WITH CLID,name,definition,biomarkers,organ

--- a/src/hs_ontology_api/cypher/celltypedetail.cypher
+++ b/src/hs_ontology_api/cypher/celltypedetail.cypher
@@ -1,82 +1,66 @@
+// OCTOBER 2025
+// Refactored:
+// 1. to use simpler linkage for terms and definitions, taking advantage of reduced
+//    ingestion of UBERON and PATO ("base" OWLs)
+// 2. to allow text searching on terms
+// 3. to return as JSON
+
+
 // Return detailed information on cell types, based on a input list of CL codes.
 // Used by the celltypes/<id>/detail route.
 
-CALL
 // Get CUIs of concepts for cell types that match the criteria.
-
-{
-
-// Criteria: Cell Ontology code
-//WITH ['0002138'] AS ids
-//WITH [''] AS ids
-
-// The calling function in neo4j_logic.py will replace $ids.
-WITH [$ids] AS ids
-
-// APRIL 2024 Bug fix to use CodeID instead of CODE for cases of leading zeroes in strings.
-// JANUARY 2025 Because PATO and UBERON are ingested prior to CL, some CL codes will associate with multiple concepts.
-// Use the concept that is associated with the code during the CL ingestion, which can be identified by the use of a
-// preferred term (term of relationship type PT).
-OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code)-[r:PT]->(tCL:Term)
-WHERE r.CUI = pCL.CUI
-AND CASE WHEN ids[0]<>'' THEN ANY(id in ids WHERE cCL.CodeID='CL:'+id) ELSE 1=1 END RETURN DISTINCT pCL.CUI AS CLCUI}
+// Note that this CALL statement is identical to that used by celltype.cypher.
 CALL
 {
 
-// CL codes and preferred term
+	// Criteria: Cell Ontology code
+	//WITH ['0002138','adipose'] AS ids
+	//WITH [''] AS ids
 
-// Cell types - CL Code|preferred term
-// CL codes can be ingested as part of the ingestion of other ontologies in UBKG (e.g. UBERON).
-// A CL code may have multiple terms of type "PT".
-// If a CL code was ingested as part of CL, then there will be a PT code; if not, then there may be one or more terms of type PT_SAB--e.g.,  PT_UBERON is the preferred term for the CL code ingested with UBERON.
-// The preferred term will be the term of type PT; if there is no PT, then any of the others of type PT_SAB will do.
+	// The calling function in neo4j_logic.py will replace $ids.
+	WITH [$ids] AS ids
 
-// First, order the preferred terms by whether they are the PT or a PT_SAB.
-WITH CLCUI
-CALL{
-WITH CLCUI
-OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term) WHERE pCL.CUI=CLCUI AND cCL.SAB='CL' AND rCL.CUI=pCL.CUI AND type(rCL) STARTS WITH 'PT' RETURN cCL.CodeID AS CLID, MIN(CASE WHEN type(rCL)='PT' THEN 0 ELSE 1 END) AS mintype order by CLID,mintype
+	// 1. Because PATO and UBERON are ingested prior to CL, some CL codes may associate with multiple concepts.
+	//    Use the concept that is associated with the code during the CL ingestion, which can be identified by the use of a
+	//    preferred term (term of relationship type PT).
+	// 2. If the id is an integer, assume a search on CL ID; otherwise, assume a search on a term.
+	// 3. Because the definition of a code is associated with the code's concept, there will generally be duplicate definitions per code.
+	//    Take the first definition in the list.
+	OPTIONAL MATCH (dCL:Definition {SAB:'CL'})<-[:DEF]-(pCL:Concept)-[:CODE]->(cCL:Code{SAB:'CL'})-[r:PT]->(tCL:Term)
+	WHERE r.CUI = pCL.CUI
+	AND (
+  		ids[0] <> '' AND
+  		ANY(id IN ids WHERE
+    		CASE
+      			WHEN id =~ '^\d+$' THEN
+        			cCL.CodeID = 'CL:' + id
+      			ELSE
+       				tCL.name CONTAINS id
+    		END
+  		)
+  		OR ids[0] = ''
+	)
+	RETURN DISTINCT pCL.CUI AS CLCUI, cCL.CodeID as CLID, tCL.name AS name, COLLECT(dCL.DEF)[0] AS definition
 }
 
-// Next, filter to either the PT or one of the PT_SABs.
-WITH CLID, mintype
-OPTIONAL MATCH (cCL:Code)-[rCL]->(tCL:Term)
-WHERE cCL.CodeID = CLID AND type(rCL) STARTS WITH 'PT'
-AND CASE WHEN type(rCL)='PT' THEN 0 ELSE 1 END=mintype
-RETURN cCL.CodeID AS CLID, 'cell_types_name' AS ret_key, CASE WHEN tCL.name IS NULL THEN '' ELSE tCL.name END AS ret_value
-ORDER BY CLID
+// DETAILS
 
-UNION
+//CL-HGNC MAPPINGS VIA HRA, ORDERED BY HGNC ID.
+CALL
+{
+	WITH CLCUI, CLID,name,definition
+	OPTIONAL MATCH (cCL:Code)<-[:CODE]-(pCL:Concept)-[:characterized_by]->(pGene:Concept)-[:CODE]->(cGene:Code)-[r]->(tGene:Term)
+	WHERE pCL.CUI=CLCUI AND cGene.SAB='HGNC' AND r.CUI=pGene.CUI AND cCL.SAB='CL' AND type(r) IN ['ACR']
+	WITH COLLECT({reference:'Human Reference Atlas', biomarker_type:'gene', entry:{vocabulary:'hgnc', id:cGene.CodeID, symbol:tGene.name}}) AS biomarker_list
+	UNWIND biomarker_list AS biomarker
+	WITH biomarker
+	ORDER BY biomarker.entry.id
+	RETURN COLLECT(biomarker) AS biomarkers
 
-// Cell types - CL code|definition
-// Because definitions link to Concepts and multiple CL codes can match to the same concept, there will be duplicate and extraneous definitions.
-// There is currently no way to link the definition to the code, so collect the definitions and take the first one.
+}
 
-WITH CLCUI
-OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code),(pCL:Concept)-[:DEF]->(dCL:Definition) WHERE pCL.CUI=CLCUI AND cCL.SAB='CL' AND dCL.SAB='CL' RETURN cCL.CodeID AS CLID,'cell_types_definition' as ret_key, COLLECT(DISTINCT dCL.DEF)[0]  as ret_value
-ORDER BY CLID
-
-UNION
-
-//CL-HGNC mappings via HRA
-// APRIL 2024 - HRA changed "has_marker_component" to "characterized_by"
-
-//HGNC ID
-WITH CLCUI
-OPTIONAL MATCH (cCL:Code)<-[:CODE]-(pCL:Concept)-[:characterized_by]->(pGene:Concept)-[:CODE]->(cGene:Code)-[r]->(tGene:Term)
-WHERE pCL.CUI=CLCUI AND cGene.SAB='HGNC' AND r.CUI=pGene.CUI AND cCL.SAB='CL' AND type(r) IN ['ACR','PT']
-WITH COLLECT(tGene.name) AS tgene_names, cGene.CodeID AS cgene_codeid, cCL.CodeID AS ccl_codeid
-WITH distinct ccl_codeid AS CLID, 'cell_types_genes' AS ret_key, cgene_codeid+'|'+apoc.text.join(tgene_names,'|') AS ret_value
-RETURN CLID, ret_key, ret_value
-ORDER BY CLID, ret_value
-
-UNION
-
-// JUNE 2025 - ANNOTATION MAPPINGS TO CELL ONTOLOGY AND UBERON
-// Revised:
-// 1. To include Azimuth, STELLAR, DeepCellType, and Pan Organ Azimuth
-// 2. To account for use of UBERON base ontology instead of UBERON
-
+// ORGANS VIA ANNOTATION MAPPINGS
 // Each annotation mapping:
 // 1. Assigns annotation cell codes to annotation organ codes.
 // 2. Assigns CL codes as cross-references to annotation cell codes.
@@ -84,62 +68,54 @@ UNION
 
 // In addition, Pan Organ Azimuth organizes annotations by "organ level".
 
-// Algorithm:
-
-// 1. Get all annotation cell type codes that are cross-referenced to CL codes.
+// FIRST, Get all annotation cell type codes that are cross-referenced to CL codes.
 // For the case of a CL code being cross-referenced to multiple codes from a mapping, only one of the codes gets the "preferred"
 // cross-reference to the CL code (via concept mapping); however, all of the mapped codes still have a cross-reference to the CL code.
-
-WITH CLCUI
 CALL
 {
-        WITH CLCUI
-        OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term),
-        (pCL:Concept)-[:CODE]->(cMap:Code)-[rMap]->(tMap:Term)
-        WHERE pCL.CUI=CLCUI AND rCL.CUI=pCL.CUI AND cCL.SAB='CL'
-        AND cMap.SAB IN['AZ','STELLAR','DCT','PAZ']
-        RETURN DISTINCT cCL.CodeID as CLID,cMap.CodeID AS mapID
-}
-// 2. Use the annotation cell codes to map to concepts that have located_in relationships with annotation organ codes.
-// Annotation organ codes are cross-referenced to UBERON codes. Limit the located_in relationships to those from annotation maps.
+	WITH CLCUI,CLID,name,definition
+	OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term),
+	(pCL:Concept)-[:CODE]->(cMap:Code)-[rMap]->(tMap:Term)
+    WHERE pCL.CUI=CLCUI
+    AND rCL.CUI=pCL.CUI
+    AND cCL.SAB='CL'
+    AND cMap.SAB IN['AZ','STELLAR','DCT','PAZ']
+    RETURN DISTINCT cMap.CodeID AS mapID
+ }
 
-WITH CLID,mapID
+// SECOND, Use the annotation cell codes to map to concepts that have located_in relationships with annotation organ codes.
+// Annotation organ codes are cross-referenced to UBERON codes. Limit the located_in relationships to those from annotation maps.
 CALL
-{   WITH mapID
-    MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:located_in]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB]->(tUB:Term)
+{
+	WITH CLCUI,CLID,name,definition,mapID
+   	OPTIONAL MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:located_in]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB]->(tUB:Term)
     WHERE rMapUB.SAB IN ['AZ','STELLAR','DCT']
     AND rUB.CUI=pUB.CUI
     AND cMap.CodeID=mapID
     AND cUB.SAB='UBERON'
     AND TYPE(rUB) STARTS WITH 'PT'
-    RETURN cUB.CodeID+'|'+ tUB.name + '|' + rMapUB.SAB as UBERONID
+    //RETURN cUB.CodeID+'|'+ tUB.name + '|' + rMapUB.SAB as UBERONID
+    RETURN cUB.CodeID AS UBCode, tUB.name AS UBName, rMapUB.SAB AS UBAnnotation
 
     UNION
-    WITH mapID
 
-    MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:has_organ_level]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB:PT]->(tUB:Term)
+    WITH CLCUI,CLID,name,definition,mapID
+    OPTIONAL MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:has_organ_level]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB:PT]->(tUB:Term)
     WHERE rMapUB.SAB ='PAZ'
     AND rUB.CUI=pUB.CUI
     AND cMap.CodeID=mapID
     AND cUB.SAB='PAZ'
-    RETURN cUB.CodeID+'|'+ tUB.name + '|' + 'PAZ' as UBERONID
-}
-
-WITH CLID,UBERONID
-RETURN DISTINCT CLID, 'cell_types_organ' as ret_key, apoc.text.join(COLLECT(DISTINCT UBERONID),",")  AS ret_value
-ORDER BY CLID, apoc.text.join(COLLECT(DISTINCT UBERONID),",")
+    //RETURN cUB.CodeID+'|'+ tUB.name + '|' + 'PAZ' as UBERONID
+    RETURN cUB.CodeID AS UBCode, tUB.name AS UBName, 'PAZ' AS UBAnnotation
 
 }
 
-//Pivot results
-
-WITH CLID, ret_key, COLLECT(ret_value) AS values
-WITH CLID,apoc.map.fromLists(COLLECT(ret_key),COLLECT(values)) AS map
+// Collect and order organs by annotation type.
+WITH CLID,name,definition,biomarkers, COLLECT({id:UBCode,name:UBName,source:'UBERON',annotation:UBAnnotation}) AS organ_list
 WHERE CLID IS NOT NULL
-RETURN CLID,
-map['cell_types_name'] AS cell_types_code_name,
-map['cell_types_definition'] AS cell_types_definition,
-map['cell_types_genes'] AS cell_types_genes,
-map['cell_types_organ'] AS cell_types_organs
-
-order by CLID
+UNWIND organ_list AS organ
+WITH CLID,name,definition,biomarkers,organ
+ORDER BY organ.annotation
+WITH CLID,name,definition,biomarkers,COLLECT(organ) AS organs
+WITH COLLECT({cell_type:{id:CLID,name:name,definition:definition,biomarkers:biomarkers,organs:organs}}) AS celltype
+RETURN celltype

--- a/src/hs_ontology_api/cypher/deprecated/celltypedetail_old.cypher
+++ b/src/hs_ontology_api/cypher/deprecated/celltypedetail_old.cypher
@@ -1,0 +1,145 @@
+// Return detailed information on cell types, based on a input list of CL codes.
+// Used by the celltypes/<id>/detail route.
+
+CALL
+// Get CUIs of concepts for cell types that match the criteria.
+
+{
+
+// Criteria: Cell Ontology code
+//WITH ['0002138'] AS ids
+//WITH [''] AS ids
+
+// The calling function in neo4j_logic.py will replace $ids.
+WITH [$ids] AS ids
+
+// APRIL 2024 Bug fix to use CodeID instead of CODE for cases of leading zeroes in strings.
+// JANUARY 2025 Because PATO and UBERON are ingested prior to CL, some CL codes will associate with multiple concepts.
+// Use the concept that is associated with the code during the CL ingestion, which can be identified by the use of a
+// preferred term (term of relationship type PT).
+OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code)-[r:PT]->(tCL:Term)
+WHERE r.CUI = pCL.CUI
+AND CASE WHEN ids[0]<>'' THEN ANY(id in ids WHERE cCL.CodeID='CL:'+id) ELSE 1=1 END RETURN DISTINCT pCL.CUI AS CLCUI}
+CALL
+{
+
+// CL codes and preferred term
+
+// Cell types - CL Code|preferred term
+// CL codes can be ingested as part of the ingestion of other ontologies in UBKG (e.g. UBERON).
+// A CL code may have multiple terms of type "PT".
+// If a CL code was ingested as part of CL, then there will be a PT code; if not, then there may be one or more terms of type PT_SAB--e.g.,  PT_UBERON is the preferred term for the CL code ingested with UBERON.
+// The preferred term will be the term of type PT; if there is no PT, then any of the others of type PT_SAB will do.
+
+// First, order the preferred terms by whether they are the PT or a PT_SAB.
+WITH CLCUI
+CALL{
+WITH CLCUI
+OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term) WHERE pCL.CUI=CLCUI AND cCL.SAB='CL' AND rCL.CUI=pCL.CUI AND type(rCL) STARTS WITH 'PT' RETURN cCL.CodeID AS CLID, MIN(CASE WHEN type(rCL)='PT' THEN 0 ELSE 1 END) AS mintype order by CLID,mintype
+}
+
+// Next, filter to either the PT or one of the PT_SABs.
+WITH CLID, mintype
+OPTIONAL MATCH (cCL:Code)-[rCL]->(tCL:Term)
+WHERE cCL.CodeID = CLID AND type(rCL) STARTS WITH 'PT'
+AND CASE WHEN type(rCL)='PT' THEN 0 ELSE 1 END=mintype
+RETURN cCL.CodeID AS CLID, 'cell_types_name' AS ret_key, CASE WHEN tCL.name IS NULL THEN '' ELSE tCL.name END AS ret_value
+ORDER BY CLID
+
+UNION
+
+// Cell types - CL code|definition
+// Because definitions link to Concepts and multiple CL codes can match to the same concept, there will be duplicate and extraneous definitions.
+// There is currently no way to link the definition to the code, so collect the definitions and take the first one.
+
+WITH CLCUI
+OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code),(pCL:Concept)-[:DEF]->(dCL:Definition) WHERE pCL.CUI=CLCUI AND cCL.SAB='CL' AND dCL.SAB='CL' RETURN cCL.CodeID AS CLID,'cell_types_definition' as ret_key, COLLECT(DISTINCT dCL.DEF)[0]  as ret_value
+ORDER BY CLID
+
+UNION
+
+//CL-HGNC mappings via HRA
+// APRIL 2024 - HRA changed "has_marker_component" to "characterized_by"
+
+//HGNC ID
+WITH CLCUI
+OPTIONAL MATCH (cCL:Code)<-[:CODE]-(pCL:Concept)-[:characterized_by]->(pGene:Concept)-[:CODE]->(cGene:Code)-[r]->(tGene:Term)
+WHERE pCL.CUI=CLCUI AND cGene.SAB='HGNC' AND r.CUI=pGene.CUI AND cCL.SAB='CL' AND type(r) IN ['ACR','PT']
+WITH COLLECT(tGene.name) AS tgene_names, cGene.CodeID AS cgene_codeid, cCL.CodeID AS ccl_codeid
+WITH distinct ccl_codeid AS CLID, 'cell_types_genes' AS ret_key, cgene_codeid+'|'+apoc.text.join(tgene_names,'|') AS ret_value
+RETURN CLID, ret_key, ret_value
+ORDER BY CLID, ret_value
+
+UNION
+
+// JUNE 2025 - ANNOTATION MAPPINGS TO CELL ONTOLOGY AND UBERON
+// Revised:
+// 1. To include Azimuth, STELLAR, DeepCellType, and Pan Organ Azimuth
+// 2. To account for use of UBERON base ontology instead of UBERON
+
+// Each annotation mapping:
+// 1. Assigns annotation cell codes to annotation organ codes.
+// 2. Assigns CL codes as cross-references to annotation cell codes.
+// 3. Assigns UBERON codes as cross-references to annotation organ codes.
+
+// In addition, Pan Organ Azimuth organizes annotations by "organ level".
+
+// Algorithm:
+
+// 1. Get all annotation cell type codes that are cross-referenced to CL codes.
+// For the case of a CL code being cross-referenced to multiple codes from a mapping, only one of the codes gets the "preferred"
+// cross-reference to the CL code (via concept mapping); however, all of the mapped codes still have a cross-reference to the CL code.
+
+WITH CLCUI
+CALL
+{
+        WITH CLCUI
+        OPTIONAL MATCH (pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term),
+        (pCL:Concept)-[:CODE]->(cMap:Code)-[rMap]->(tMap:Term)
+        WHERE pCL.CUI=CLCUI AND rCL.CUI=pCL.CUI AND cCL.SAB='CL'
+        AND cMap.SAB IN['AZ','STELLAR','DCT','PAZ']
+        RETURN DISTINCT cCL.CodeID as CLID,cMap.CodeID AS mapID
+}
+// 2. Use the annotation cell codes to map to concepts that have located_in relationships with annotation organ codes.
+// Annotation organ codes are cross-referenced to UBERON codes. Limit the located_in relationships to those from annotation maps.
+
+WITH CLID,mapID
+CALL
+{   WITH mapID
+    MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:located_in]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB]->(tUB:Term)
+    WHERE rMapUB.SAB IN ['AZ','STELLAR','DCT']
+    AND rUB.CUI=pUB.CUI
+    AND cMap.CodeID=mapID
+    AND cUB.SAB='UBERON'
+    AND TYPE(rUB) STARTS WITH 'PT'
+    RETURN cUB.CodeID+'|'+ tUB.name + '|' + rMapUB.SAB as UBERONID
+
+    UNION
+    WITH mapID
+
+    MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:has_organ_level]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB:PT]->(tUB:Term)
+    WHERE rMapUB.SAB ='PAZ'
+    AND rUB.CUI=pUB.CUI
+    AND cMap.CodeID=mapID
+    AND cUB.SAB='PAZ'
+    RETURN cUB.CodeID+'|'+ tUB.name + '|' + 'PAZ' as UBERONID
+}
+
+WITH CLID,UBERONID
+RETURN DISTINCT CLID, 'cell_types_organ' as ret_key, apoc.text.join(COLLECT(DISTINCT UBERONID),",")  AS ret_value
+ORDER BY CLID, apoc.text.join(COLLECT(DISTINCT UBERONID),",")
+
+}
+
+//Pivot results
+
+WITH CLID, ret_key, COLLECT(ret_value) AS values
+WITH CLID,apoc.map.fromLists(COLLECT(ret_key),COLLECT(values)) AS map
+WHERE CLID IS NOT NULL
+RETURN CLID,
+map['cell_types_name'] AS cell_types_code_name,
+map['cell_types_definition'] AS cell_types_definition,
+map['cell_types_genes'] AS cell_types_genes,
+map['cell_types_organ'] AS cell_types_organs
+
+order by CLID

--- a/src/hs_ontology_api/cypher/deprecated/genedetail_old.cypher
+++ b/src/hs_ontology_api/cypher/deprecated/genedetail_old.cypher
@@ -1,0 +1,203 @@
+// GENE DETAIL
+// Return detailed information on a gene, based on a input list of HGNC identifiers.
+// Used by the genes/id/detail endpoint.
+
+CALL
+
+// Get CUIs of concepts for genes that match the criteria.
+
+{
+
+// Criteria: list of HGNC identifiers.
+
+// The following types of identifiers can be used in the list:
+// 1. HGNC numeric IDs (e.g., 7178)
+// 2. HGNC approved symbols (e.g., MMRN1)
+// 3. HGNC previous symbols (e.g., MMRN)
+// 4. HGNC aliases (e.g., ECM)
+// 5. names (approved name, previous name, alias name). Because exact matches would be required, it is unlikely that names would be useful criteria.
+
+// If no criteria are specified, return information on all HGNC genes.
+
+//WITH ['60','MMRN1'] AS ids
+
+// The calling function in neo4j_logic.py will replace $ids.
+WITH [$ids] AS ids
+
+// Find CUIs for genes that satisfy criteria for HGNC ID or term (symbol, name). The preferred CUI for each HGNC Code can be identified by the CUI property of any relationship between the code and one of its terms--e.g., PT.
+OPTIONAL MATCH (pGene:Concept)-[:CODE]->(cGene:Code)-[r]->(tGene:Term) WHERE r.CUI=pGene.CUI AND type(r) IN ['PT','ACR','NS','NP','SYN','NA_UBKG'] AND cGene.SAB='HGNC' AND CASE WHEN ids[0]<>'' THEN (ANY(id IN ids WHERE cGene.CODE=id) or ANY(id in ids WHERE tGene.name=id)) ELSE 1=1 END RETURN DISTINCT pGene.CUI AS GeneCUI
+
+}
+
+CALL{
+
+// Gene symbols, names, aliases, prior values
+WITH GeneCUI
+OPTIONAL MATCH (pGene:Concept)-[:CODE]->(cGene:Code)-[r]->(tGene:Term) WHERE pGene.CUI=GeneCUI AND r.CUI=pGene.CUI AND type(r) IN ['PT','ACR','NS','NP','SYN','NA_UBKG'] AND cGene.SAB='HGNC' RETURN toInteger(cGene.CODE) AS hgnc_id, CASE type(r) WHEN 'PT' THEN 'approved_name' WHEN 'ACR' THEN 'approved_symbol' WHEN 'NS' THEN 'previous_symbols' WHEN 'NP' THEN 'previous_names' WHEN 'SYN' THEN 'alias_symbols' WHEN 'NA_UBKG' THEN 'alias_names' ELSE type(r) END AS ret_key,tGene.name AS ret_value
+ORDER BY hgnc_id, ret_key
+
+UNION
+
+// References to other vocabularies (Entrez, Ensembl, OMIM)
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:CODE]->(cRef:Code) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND cRef.SAB IN ['ENTREZ','ENSEMBL','OMIM'] RETURN toInteger(cGene.CODE) as hgnc_id, 'references' AS ret_key, cRef.CodeID AS ret_value
+ORDER BY hgnc_id, ret_key
+
+UNION
+
+// References to HUGO (HGNC)
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' RETURN toInteger(cGene.CODE) as hgnc_id, 'references' AS ret_key, cGene.CodeID AS ret_value
+ORDER BY hgnc_id, ret_key
+
+UNION
+
+// References to gene products of genes from UNIPROTKB
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:has_gene_product]->(pProtein:Concept)-[:CODE]->(cProtein:Code) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' RETURN toInteger(cGene.CODE) AS hgnc_id, 'references' AS ret_key, cProtein.CodeID AS ret_value
+ORDER BY hgnc_id,ret_key
+
+UNION
+
+// RefSeq summaries, with backslashes in text replaced with forward slashes
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:DEF]->(dGene:Definition) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND dGene.SAB='REFSEQ' RETURN toInteger(cGene.CODE) AS hgnc_id, 'summary' AS ret_key, replace(dGene.DEF,'\\','/') AS ret_value
+ORDER BY hgnc_id,ret_key
+
+// CELL TYPE INFORMATION
+// Gene to cell type mappings are from the Human Reference Atlas (HRA).
+// Cell type information is flattened because a gene can associate with multiple cell types.
+// Properties of cell type (from Cell Ontology) except for code are optional.
+// Each property will be a list keyed with the CL code--e.g., CL:code1|property,CL:code2|property
+// A script can split the lists in each of the cell_type fields and find all properties for a particular CL
+
+UNION
+
+//Cell types - CL Codes
+// APRIL 2024 - HRA changed "has_marker_component" to "characterized_by"
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:inverse_characterized_by]->(pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND cCL.SAB='CL' AND rCL.CUI=pCL.CUI  RETURN toInteger(cGene.CODE) AS hgnc_id, 'cell_types_code' AS  ret_key, cCL.CodeID AS ret_value
+ORDER BY  hgnc_id,ret_key,ret_value
+
+UNION
+
+// Cell types - CL Code|preferred term
+// CL codes can be ingested as part of the ingestion of other ontologies in UBKG (e.g. UBERON).
+// A CL code may have multiple terms of type "PT".
+// If a CL code was ingested as part of CL, then there will be a PT code; if not, then there may be one or more terms of type PT_SAB--e.g.,  PT_UBERON is the preferred term for the CL code ingested with UBERON.
+// The preferred term will be the term of type PT; if there is no PT, then any of the others of type PT_SAB will do.
+
+// First, order the preferred terms by whether they are the PT or a PT_SAB.
+// APRIL 2024 - HRA changed the label from "has_marker_component" to "characterized_by"
+WITH GeneCUI
+CALL{
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:inverse_characterized_by]->(pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND cCL.SAB='CL' AND rCL.CUI=pCL.CUI AND type(rCL) STARTS WITH 'PT' RETURN toInteger(cGene.CODE) AS hgnc_id, cCL.CodeID AS CLID, MIN(CASE WHEN type(rCL)='PT' THEN 0 ELSE 1 END) AS mintype order by hgnc_id,CLID,mintype
+}
+
+// Next, filter to either the PT or one of the PT_SABs.
+// MARCH 2024 - WITH used in return to upgrade to v5 Cypher.
+WITH hgnc_id, CLID, mintype
+OPTIONAL MATCH (cCL:Code)-[rCL]->(tCL:Term)
+where cCL.CodeID = CLID AND type(rCL) STARTS WITH 'PT'
+AND CASE WHEN type(rCL)='PT' THEN 0 ELSE 1 END=mintype
+WITH hgnc_id, 'cell_types_name' AS ret_key, CLID +'|'+ CASE WHEN tCL.name IS NULL THEN '' ELSE tCL.name END AS ret_value
+RETURN hgnc_id, ret_key, ret_value
+
+UNION
+
+// Cell types - CL code|definition
+// Definitions link to Concepts and multiple CL codes can match to the same concept; however, each CL code has a "preferred" CUI, identified by the CUI property of the relationship of any of the code's linked terms.
+
+// MARCH 2024 - final WITH added to work with v5 Cypher
+// APRIL 2024 - HRA changed "has_marker_component" to "characterized_by"
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:inverse_characterized_by]->(pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term),(pCL:Concept)-[:DEF]->(dCL:Definition) WHERE rCL.CUI=pCL.CUI AND pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND cCL.SAB='CL' AND dCL.SAB='CL'
+WITH toInteger(cGene.CODE) AS hgnc_id,'cell_types_definition' as ret_key, cCL.CodeID + '|'+ dCL.DEF as ret_value
+RETURN DISTINCT hgnc_id, ret_key, ret_value
+ORDER BY hgnc_id, ret_value
+
+UNION
+
+// JUNE 2025 - ANNOTATION MAPPINGS TO CELL ONTOLOGY AND UBERON
+// Revised:
+// 1. To include Azimuth, STELLAR, DeepCellType, and Pan Organ Azimuth
+// 2. To account for use of UBERON base ontology instead of UBERON
+
+// Each annotation mapping:
+// 1. Assigns annotation cell codes to annotation organ codes.
+// 2. Assigns CL codes as cross-references to annotation cell codes.
+// 3. Assigns UBERON codes as cross-references to annotation organ codes.
+
+// In addition, Pan Organ Azimuth organizes annotations by "organ level".
+
+// APRIL 2024 - HRA changed "has_marker_component" to "characterized_by"
+
+WITH GeneCUI
+//First, get annotation mapping codes that are cross-referenced to CL codes. For the case of a CL code being cross-referenced to multiple codes from an annotation mapping, only one code gets the "preferred" cross-reference to the CL code; however, all codes of an annotation mapping have a cross-reference to the CL code, so do not check on the CUI value of the term relationship.
+CALL
+{WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:inverse_characterized_by]->(pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term), (pCL:Concept)-[:CODE]->(cMap:Code)-[rMap]->(tMap:Term) WHERE rCL.CUI=pCL.CUI AND pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND cCL.SAB='CL' AND cMap.SAB IN['AZ','STELLAR','DCT','PAZ'] RETURN DISTINCT toInteger(cGene.CODE) AS hgnc_id,cCL.CodeID as CLID,cMap.CodeID AS mapID}
+
+//Use the annotation mapping codes to map to concepts that have located_in relationships with annotation mapping organ codes.
+//The mapping organ codes are cross-referenced to UBERON codes.
+// Limit the located_in relationships to those from annotation maps.
+// For PAZ and downward compatibility, overload the organ code with the PAZ "organ_level" code.
+
+CALL
+{
+	WITH mapID
+    MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:located_in]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB]->(tUB:Term)
+    WHERE rMapUB.SAB IN['AZ','STELLAR','DCT']
+    AND rUB.CUI=pUB.CUI
+    AND cMap.CodeID=mapID
+    AND cUB.SAB='UBERON'
+    AND TYPE(rUB) STARTS WITH 'PT'
+    RETURN cUB.CodeID+'*'+ tUB.name + '' as UBERONID
+
+	UNION
+
+	WITH mapID
+	MATCH (cMap:Code)<-[:CODE]-(pMap:Concept)-[rMapUB:has_organ_level]->(pUB:Concept)-[:CODE]->(cUB:Code)-[rUB:PT]->(tUB:Term)
+    WHERE rMapUB.SAB ='PAZ'
+    AND rUB.CUI=pUB.CUI
+    AND cMap.CodeID=mapID
+    AND cUB.SAB='PAZ'
+    RETURN cUB.CodeID+'*'+ tUB.name + '' as UBERONID
+
+}
+
+WITH hgnc_id, 'cell_types_organ' as ret_key, CLID,UBERONID, CLID+ '|' + apoc.text.join(COLLECT(DISTINCT UBERONID),",") AS ret_value
+RETURN DISTINCT hgnc_id, ret_key, ret_value
+ORDER BY hgnc_id, ret_value
+
+// Indicate the source of cell type information.
+// APRIL 2024 - HRA changed "has_marker_component" to "characterized_by"
+UNION
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:inverse_characterized_by]->(pCL:Concept)-[:CODE]->(cCL:Code)-[rCL]->(tCL:Term) WHERE rCL.CUI=pCL.CUI AND pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND cCL.SAB='CL' RETURN DISTINCT toInteger(cGene.CODE) AS hgnc_id,'cell_types_source' as ret_key, cCL.CodeID + '|Human Reference Atlas' as ret_value
+ORDER BY hgnc_id,cCL.CodeID + '|Human Reference Atlas'
+
+}
+
+// APRIL 2024 bug fix check for null gene before calling fromlists
+
+WITH hgnc_id, ret_key, COLLECT(ret_value) AS values
+WHERE hgnc_id IS NOT NULL
+WITH hgnc_id,apoc.map.fromLists(COLLECT(ret_key),COLLECT(values)) AS map
+RETURN hgnc_id,
+map['approved_symbol'] AS approved_symbol,
+map['approved_name'] AS approved_name,
+map['previous_symbols'] AS previous_symbols,
+map['previous_names'] AS previous_names,
+map['alias_symbols'] AS alias_symbols,
+map['alias_names'] AS alias_names,
+map['references'] AS references,
+map['summary'] AS summaries,
+map['cell_types_code'] AS cell_types_code,
+map['cell_types_name'] AS cell_types_code_name,
+map['cell_types_definition'] AS cell_types_code_definition,
+map['cell_types_organ'] AS cell_types_codes_organ,
+map['cell_types_source'] AS cell_types_codes_source
+
+order by hgnc_id

--- a/src/hs_ontology_api/cypher/gene.cypher
+++ b/src/hs_ontology_api/cypher/gene.cypher
@@ -65,6 +65,7 @@ WITH hgnc_id,apoc.map.fromLists(COLLECT(ret_key),COLLECT(values)) AS map
 
 WITH hgnc_id,
 	{
+	    hgnc_id:hgnc_id,
 		approved_name:map['approved_name'][0],
 		approved_symbol:map['approved_symbol'][0],
 		previous_symbols:map['previous_symbols'],

--- a/src/hs_ontology_api/cypher/gene.cypher
+++ b/src/hs_ontology_api/cypher/gene.cypher
@@ -1,0 +1,79 @@
+// GENES
+// Return reference information on a gene, based on a input list of HGNC identifiers.
+// Used by the genes endpoint.
+
+CALL
+
+// Get CUIs of concepts for genes that match the criteria.
+
+{
+
+// Criteria: list of HGNC identifiers.
+
+// The following types of identifiers can be used in the list:
+// 1. HGNC numeric IDs (e.g., 7178)
+// 2. HGNC approved symbols (e.g., MMRN1)
+// 3. HGNC previous symbols (e.g., MMRN)
+// 4. HGNC aliases (e.g., ECM)
+// 5. names (approved name, previous name, alias name). Because exact matches would be required, it is unlikely that names would be useful criteria.
+
+// If no criteria are specified, return information on all HGNC genes.
+
+//WITH ['60','MMRN1'] AS ids
+
+// The calling function in neo4j_logic.py will replace $ids.
+WITH [$ids] AS ids
+
+// Find CUIs for genes that satisfy criteria for HGNC ID or term (symbol, name). The preferred CUI for each HGNC Code can be identified by the CUI property of any relationship between the code and one of its terms--e.g., PT.
+OPTIONAL MATCH (pGene:Concept)-[:CODE]->(cGene:Code)-[r]->(tGene:Term) WHERE r.CUI=pGene.CUI AND type(r) IN ['PT','ACR','NS','NP','SYN','NA_UBKG'] AND cGene.SAB='HGNC' AND CASE WHEN ids[0]<>'' THEN (ANY(id IN ids WHERE cGene.CODE=id) or ANY(id in ids WHERE tGene.name=id)) ELSE 1=1 END RETURN DISTINCT pGene.CUI AS GeneCUI
+
+}
+
+CALL{
+
+// Gene symbols, names, aliases, prior values
+WITH GeneCUI
+OPTIONAL MATCH (pGene:Concept)-[:CODE]->(cGene:Code)-[r]->(tGene:Term) WHERE pGene.CUI=GeneCUI AND r.CUI=pGene.CUI AND type(r) IN ['PT','ACR','NS','NP','SYN','NA_UBKG'] AND cGene.SAB='HGNC' RETURN toInteger(cGene.CODE) AS hgnc_id, CASE type(r) WHEN 'PT' THEN 'approved_name' WHEN 'ACR' THEN 'approved_symbol' WHEN 'NS' THEN 'previous_symbols' WHEN 'NP' THEN 'previous_names' WHEN 'SYN' THEN 'alias_symbols' WHEN 'NA_UBKG' THEN 'alias_names' ELSE type(r) END AS ret_key,tGene.name AS ret_value
+ORDER BY hgnc_id, ret_key
+
+UNION
+
+// References to other vocabularies (Entrez, Ensembl, OMIM)
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:CODE]->(cRef:Code) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND cRef.SAB IN ['ENTREZ','ENSEMBL','OMIM'] RETURN toInteger(cGene.CODE) as hgnc_id, 'references' AS ret_key, cRef.CodeID AS ret_value
+ORDER BY hgnc_id, ret_key
+
+UNION
+
+// References to HUGO (HGNC)
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' RETURN toInteger(cGene.CODE) as hgnc_id, 'references' AS ret_key, cGene.CodeID AS ret_value
+ORDER BY hgnc_id, ret_key
+
+UNION
+
+// RefSeq summaries, with backslashes in text replaced with forward slashes
+WITH GeneCUI
+OPTIONAL MATCH (cGene:Code)<-[:CODE]-(pGene:Concept)-[:DEF]->(dGene:Definition) WHERE pGene.CUI=GeneCUI AND cGene.SAB='HGNC' AND dGene.SAB='REFSEQ' RETURN toInteger(cGene.CODE) AS hgnc_id, 'summary' AS ret_key, replace(dGene.DEF,'\\','/') AS ret_value
+ORDER BY hgnc_id,ret_key
+
+}
+
+WITH hgnc_id, ret_key, COLLECT(ret_value) AS values
+WHERE hgnc_id IS NOT NULL
+WITH hgnc_id,apoc.map.fromLists(COLLECT(ret_key),COLLECT(values)) AS map
+
+WITH hgnc_id,
+	{
+		approved_name:map['approved_name'][0],
+		approved_symbol:map['approved_symbol'][0],
+		previous_symbols:map['previous_symbols'],
+		previous_names:map['previous_names'],
+		alias_symbols:map['alias_symbols'],
+		alias_names:map['alias_names'],
+		references:map['references'],
+		summary:map['summary']
+
+	} AS gene
+WHERE hgnc_id IS NOT NULL
+RETURN COLLECT(gene) AS genes

--- a/src/hs_ontology_api/cypher/genedetail.cypher
+++ b/src/hs_ontology_api/cypher/genedetail.cypher
@@ -1,6 +1,6 @@
 // GENE DETAIL
 // Return detailed information on a gene, based on a input list of HGNC identifiers.
-// Used by the gene endpoint.
+// Used by the genes/id/detail endpoint.
 
 CALL
 

--- a/src/hs_ontology_api/routes/celltypes/celltypes_controller.py
+++ b/src/hs_ontology_api/routes/celltypes/celltypes_controller.py
@@ -9,19 +9,28 @@ from ubkg_api.utils.http_error_string import get_404_error_string
 
 celltypes_blueprint = Blueprint('celltypes', __name__, url_prefix='/celltypes')
 
-@celltypes_blueprint.route('/<clid>/detail', methods=['GET'])
-def celltypes_id_detail_expand_get(clid=None):
+@celltypes_blueprint.route('/<ids>/detail', methods=['GET'])
+def celltypes_id_detail_expand_get(ids=None):
     """Returns detailed information on a single cell type.
 
     :rtype: Union[List[CellTypeDetail]]
 
     """
 
+    listids = ids.split(',')
+    clids = []
+    # Pad numeric ids with zeroes to 7 characters.
+    for i in listids:
+        if i.isnumeric():
+            clids.append(f'{int(i):07d}')
+        else:
+            clids.append(i)
+
     neo4j_instance = current_app.neo4jConnectionHelper.instance()
-    result = celltypedetail_get_logic(neo4j_instance, clid)
+    result = celltypedetail_get_logic(neo4j_instance, clids)
     if result is None or result == []:
         # Empty result
-        err = get_404_error_string(prompt_string=f'No cell types with Cell Ontology identifier')
+        err = get_404_error_string(prompt_string=f'No cell types with Cell Ontology identifiers')
         return make_response(err, 404)
 
     # March 2025

--- a/src/hs_ontology_api/routes/celltypes/celltypes_controller.py
+++ b/src/hs_ontology_api/routes/celltypes/celltypes_controller.py
@@ -44,8 +44,6 @@ def celltypes_id_get(ids=None):
             clids.append(f'{int(i):07d}')
         else:
             clids.append(i)
-            #err = get_404_error_string(prompt_string=f'Invalid Cell Ontology ID: {i}')
-            #return make_response(err, 404)
 
     neo4j_instance = current_app.neo4jConnectionHelper.instance()
     result = celltype_get_logic(neo4j_instance, clids)

--- a/src/hs_ontology_api/routes/celltypes/celltypes_controller.py
+++ b/src/hs_ontology_api/routes/celltypes/celltypes_controller.py
@@ -38,13 +38,14 @@ def celltypes_id_get(ids=None):
 
     listids = ids.split(',')
     clids = []
-    # Validate ids. Pad with zeroes to 7 characters.
+    # Pad numeric ids with zeroes to 7 characters.
     for i in listids:
         if i.isnumeric():
             clids.append(f'{int(i):07d}')
         else:
-            err = get_404_error_string(prompt_string=f'Invalid Cell Ontology ID: {i}')
-            return make_response(err, 404)
+            clids.append(i)
+            #err = get_404_error_string(prompt_string=f'Invalid Cell Ontology ID: {i}')
+            #return make_response(err, 404)
 
     neo4j_instance = current_app.neo4jConnectionHelper.instance()
     result = celltype_get_logic(neo4j_instance, clids)

--- a/src/hs_ontology_api/routes/celltypes/celltypes_controller.py
+++ b/src/hs_ontology_api/routes/celltypes/celltypes_controller.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # JAS November 2023
 from flask import Blueprint, jsonify, current_app, make_response
-from hs_ontology_api.utils.neo4j_logic import celltypedetail_get_logic
+from hs_ontology_api.utils.neo4j_logic import celltypedetail_get_logic, celltype_get_logic
 # March 2025
 # S3 redirect functions
 from ubkg_api.utils.s3_redirect import redirect_if_large
@@ -9,8 +9,8 @@ from ubkg_api.utils.http_error_string import get_404_error_string
 
 celltypes_blueprint = Blueprint('celltypes', __name__, url_prefix='/celltypes')
 
-@celltypes_blueprint.route('/<id>', methods=['GET'])
-def celltypes_id_expand_get(id=None):
+@celltypes_blueprint.route('/<clid>/detail', methods=['GET'])
+def celltypes_id_detail_expand_get(clid=None):
     """Returns detailed information on a single cell type.
 
     :rtype: Union[List[CellTypeDetail]]
@@ -18,10 +18,39 @@ def celltypes_id_expand_get(id=None):
     """
 
     neo4j_instance = current_app.neo4jConnectionHelper.instance()
-    result = celltypedetail_get_logic(neo4j_instance, id)
+    result = celltypedetail_get_logic(neo4j_instance, clid)
     if result is None or result == []:
         # Empty result
-        err = get_404_error_string(prompt_string=f'No cell types with Cell Ontology identifer')
+        err = get_404_error_string(prompt_string=f'No cell types with Cell Ontology identifier')
+        return make_response(err, 404)
+
+    # March 2025
+    # Redirect to S3 if payload is large.
+    return redirect_if_large(resp=result)
+
+@celltypes_blueprint.route('/<ids>', methods=['GET'])
+def celltypes_id_get(ids=None):
+    """
+    Returns reference information on a set of cell types.
+    :param ids: comma-delimited list of Cell Ontology IDs, including leading zeroes.
+
+    """
+
+    listids = ids.split(',')
+    clids = []
+    # Validate ids. Pad with zeroes to 7 characters.
+    for i in listids:
+        if i.isnumeric():
+            clids.append(f'{int(i):07d}')
+        else:
+            err = get_404_error_string(prompt_string=f'Invalid Cell Ontology ID: {i}')
+            return make_response(err, 404)
+
+    neo4j_instance = current_app.neo4jConnectionHelper.instance()
+    result = celltype_get_logic(neo4j_instance, clids)
+    if result is None or result == []:
+        # Empty result
+        err = get_404_error_string(prompt_string=f'No cell types with Cell Ontology identifiers')
         return make_response(err, 404)
 
     # March 2025

--- a/src/hs_ontology_api/routes/genes/genes_controller.py
+++ b/src/hs_ontology_api/routes/genes/genes_controller.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # JAS September 2023
 from flask import Blueprint, jsonify, current_app, make_response
-from hs_ontology_api.utils.neo4j_logic import genedetail_get_logic
+from hs_ontology_api.utils.neo4j_logic import genedetail_get_logic, gene_get_logic
 # March 2025
 # S3 redirect functions
 from ubkg_api.utils.s3_redirect import redirect_if_large
@@ -9,9 +9,9 @@ from ubkg_api.utils.http_error_string import get_404_error_string
 
 genes_blueprint = Blueprint('genes', __name__, url_prefix='/genes')
 
-@genes_blueprint.route('/<id>', methods=['GET'])
-def genes_id_expand_get(id=None):
-    """Returns detailed information on a single gene.
+@genes_blueprint.route('/<id>/detail', methods=['GET'])
+def genes_id_detail_expand_get(id=None):
+    """Returns detailed information on a single gene, including annotation mappings.
 
     :rtype: Union[List[GeneDetail]]
 
@@ -34,5 +34,35 @@ def genes_id_expand_get(id=None):
         return make_response(err, 404)
 
     # March 2025
+    # Redirect to S3 if payload is large.
+    return redirect_if_large(resp=result)
+
+@genes_blueprint.route('/<ids>', methods=['GET'])
+def genes_id_expand_get(ids=None):
+    """
+    OCTOBER 2025
+    Returns detailed information for genes that match a set of gene identifiers
+
+    The following types of identifiers can be used in the list:
+    1. HGNC numeric IDs (e.g., 7178)
+    2. HGNC approved symbols (e.g., MMRN1)
+    3. HGNC previous symbols (e.g., MMRN)
+    4. HGNC aliases (e.g., ECM)
+    5. names (approved name, previous name, alias name).
+
+    Because exact matches would be required, it is unlikely that names would be useful criteria.
+
+    """
+
+    geneids = ids.split(',')
+    print('geneids',geneids)
+
+    neo4j_instance = current_app.neo4jConnectionHelper.instance()
+    result = gene_get_logic(neo4j_instance, geneids)
+    if result is None or result == []:
+        # Empty result
+        err = get_404_error_string(prompt_string=f'No genes with identifiers')
+        return make_response(err, 404)
+
     # Redirect to S3 if payload is large.
     return redirect_if_large(resp=result)

--- a/src/hs_ontology_api/routes/genes/genes_controller.py
+++ b/src/hs_ontology_api/routes/genes/genes_controller.py
@@ -9,8 +9,8 @@ from ubkg_api.utils.http_error_string import get_404_error_string
 
 genes_blueprint = Blueprint('genes', __name__, url_prefix='/genes')
 
-@genes_blueprint.route('/<id>/detail', methods=['GET'])
-def genes_id_detail_expand_get(id=None):
+@genes_blueprint.route('/<ids>/detail', methods=['GET'])
+def genes_id_detail_expand_get(ids=None):
     """Returns detailed information on a single gene, including annotation mappings.
 
     :rtype: Union[List[GeneDetail]]
@@ -26,14 +26,15 @@ def genes_id_detail_expand_get(id=None):
 
     """
 
+    geneids = ids.split(',')
+
     neo4j_instance = current_app.neo4jConnectionHelper.instance()
-    result = genedetail_get_logic(neo4j_instance, id)
+    result = genedetail_get_logic(neo4j_instance, geneids)
     if result is None or result == []:
         # Empty result
-        err = get_404_error_string(prompt_string=f'No genes with HGNC identifier')
+        err = get_404_error_string(prompt_string=f'No genes with identifiers')
         return make_response(err, 404)
 
-    # March 2025
     # Redirect to S3 if payload is large.
     return redirect_if_large(resp=result)
 
@@ -55,7 +56,6 @@ def genes_id_expand_get(ids=None):
     """
 
     geneids = ids.split(',')
-    print('geneids',geneids)
 
     neo4j_instance = current_app.neo4jConnectionHelper.instance()
     result = gene_get_logic(neo4j_instance, geneids)

--- a/src/hs_ontology_api/utils/neo4j_logic.py
+++ b/src/hs_ontology_api/utils/neo4j_logic.py
@@ -1040,10 +1040,13 @@ def celltype_get_logic(neo4j_instance, searchids:list[str]) -> list:
     queryfile = 'celltype.cypher'
     querytxt = loadquerystring(queryfile)
     ids = format_list_for_query(listquery=searchids)
+    print(ids)
     querytxt = querytxt.replace('$ids', ids)
+    print(querytxt)
 
     # Set timeout for query based on value in app.cfg.
     query = neo4j.Query(text=querytxt, timeout=neo4j_instance.timeout)
+
 
     with neo4j_instance.driver.session() as session:
         try:
@@ -1749,24 +1752,3 @@ def pathway_participants_get_logic(neo4j_instance, pathwayid=None, sabs=None,
 
     if len(participants) > 0:
         return participants[0]
-
-def format_list_for_query(listquery: list[str], doublequote: bool = False) -> str:
-    """
-    Converts a list of string values into a comma-delimited, delimited string for use in a Cypher query clause.
-    :param listquery: list of string values
-    :param doublequote: flag to set the delimiter.
-
-    The default is a single quote; however, when a query
-    is the argument for the apoc.timebox function, the delimiter should be double quote.
-
-    Example:
-        listquery: ['SNOMEDCT_US', 'HGNC']
-        return:
-            doublequote = False: "'SNOMEDCT_US', 'HGNC'"
-            doublequote = True: '"SNOMEDCT_US","HGNC"'
-
-    """
-    if doublequote:
-        return ', '.join('"{0}"'.format(s) for s in listquery)
-    else:
-        return ', '.join("'{0}'".format(s) for s in listquery)

--- a/test/hs-ontology-api-system-test.sh
+++ b/test/hs-ontology-api-system-test.sh
@@ -373,6 +373,14 @@ echo
 echo | tee -a $testout
 echo | tee -a $testout
 
+echo "/celltypes/2138,236" | tee -a $testout
+curl --request GET \
+ --url "${UBKG_URL}/celltypes/2138,236" \
+ --header "Content-Type: application/json" | cut -c1-60 | tee -a $testout
+echo
+echo | tee -a $testout
+echo | tee -a $testout
+
 echo "/celltypes/0002138" | tee -a $testout
 curl --request GET \
  --url "${UBKG_URL}/celltypes/0002138" \

--- a/test/hs-ontology-api-unit-test.sh
+++ b/test/hs-ontology-api-unit-test.sh
@@ -556,13 +556,27 @@ echo | tee -a $testout
 
 # Test for celltypes endpoint.
 echo "TESTS FOR: celltypes GET" | tee -a $testout
-echo "SIGNATURE: /celltypes/<CL code>" | tee -a $testout
+echo "SIGNATURE: /celltypes/<comma-delimited list of codes>" | tee -a $testout
 echo | tee -a $testout
 echo | tee -a $testout
 
-echo "/celltypes/0002138 => should return 200" | tee -a $testout
+echo "/celltypes/2138,236 => should return 200" | tee -a $testout
 curl --request GET \
- --url "${UBKG_URL}/celltypes/0002138" \
+ --url "${UBKG_URL}/celltypes/2138,236" \
+ --header "Content-Type: application/json" | cut -c1-60 | tee -a $testout
+echo
+echo | tee -a $testout
+echo | tee -a $testout
+
+# Test for celltypes/detail endpoint.
+echo "TESTS FOR: celltypes/detail GET" | tee -a $testout
+echo "SIGNATURE: /celltypes/<CL code>/detail" | tee -a $testout
+echo | tee -a $testout
+echo | tee -a $testout
+
+echo "/celltypes/0002138/detail => should return 200" | tee -a $testout
+curl --request GET \
+ --url "${UBKG_URL}/celltypes/0002138/detail" \
  --header "Content-Type: application/json" | cut -c1-60 | tee -a $testout
 echo
 echo | tee -a $testout


### PR DESCRIPTION
CELLTYPES
1. The celltypes endpoint now returns only reference information for celltypes.
2. A new endpoint, celltypes/<list of ids>/detail, returns detailed information for celltypes, including both celltype-marker (gene) assertions from HRA and celltype-organ mappings based on assertions including Azimuth, STELLAR, DeepCellType, and Pan Organ Azimuth.
3. Cypher queries were updated to take advantage of streamlined UBERON and PATO ingestions. In addition, queries stream as JSON.
4. Both endpoints accept a comma-delimited string of identifiers.

GENES
1. The genes endpoint now only returns reference information for genes.
2. A new endpoint, genes<list of ids>/detail, returns detailed information for genes, including gene-celltypes assertions from HRA and gene-organ mappings from annotations.
3. Cypher queries for genes endpoints were updated similarly to those for celltypes.
4. Both endpoints accept a comma-delimited string of identifiers