### PR TITLE
added back references as objects with urls to genes and genes/detail endpoints

### DIFF
--- a/src/hs_ontology_api/cypher/gene.cypher
+++ b/src/hs_ontology_api/cypher/gene.cypher
@@ -75,8 +75,11 @@ WITH hgnc_id,apoc.map.fromLists(COLLECT(ret_key),COLLECT(values)) AS map
 WITH hgnc_id, map,
         [ref IN map['references'] |
                 {
-                        id: ref,
-                        source: split(ref,':')[0],
+                        id: split(ref,':')[1],
+                        source: CASE split(ref,':')[0]
+                                WHEN 'HGNC' THEN 'hugo'
+                                ELSE toLower(split(ref,':')[0])
+                        END,
                         url: CASE split(ref,':')[0]
                                 WHEN 'UNIPROTKB' THEN 'https://www.uniprot.org/uniprot/' + split(ref,':')[1]
                                 WHEN 'ENSEMBL' THEN 'https://www.ensembl.org/id/' + split(ref,':')[1]

--- a/src/hs_ontology_api/cypher/genedetail.cypher
+++ b/src/hs_ontology_api/cypher/genedetail.cypher
@@ -137,8 +137,11 @@ WITH hgnc_id,apoc.map.fromLists(COLLECT(ret_key),COLLECT(values)) AS map
 WITH hgnc_id, map,
         [ref IN map['references'] |
                 {
-                        id: ref,
-                        source: split(ref,':')[0],
+                        id: split(ref,':')[1],
+                        source: CASE split(ref,':')[0]
+                                WHEN 'HGNC' THEN 'hugo'
+                                ELSE toLower(split(ref,':')[0])
+                        END,
                         url: CASE split(ref,':')[0]
                                 WHEN 'UNIPROTKB' THEN 'https://www.uniprot.org/uniprot/' + split(ref,':')[1]
                                 WHEN 'ENSEMBL' THEN 'https://www.ensembl.org/id/' + split(ref,':')[1]


### PR DESCRIPTION
The original version of the code built reference objects in the controller after executing the cypher. The refactored version builds reference objects in the cypher. The fix adds the functionality that was originally in the controller to the cypher.