### PR TITLE
Omit dataset modalities for HuBMAP

### DIFF
--- a/src/hs_ontology_api/cypher/assayclass.cypher
+++ b/src/hs_ontology_api/cypher/assayclass.cypher
@@ -206,28 +206,27 @@ CALL
 // Response
 CALL
 {
-WITH
-context, CodeRBD, NameRBD, assaytype, dir_schema, tbl_schema,
+WITH context, CodeRBD, NameRBD, assaytype, dir_schema, tbl_schema,
 vitessce_hints,process_state,pipeline_shorthand,
 description,dataset_type_summary,
-is_multiassay,must_contain,active_status, contains_full_genetic_sequences, sn_dataset_modality
-RETURN
+is_multiassay,must_contain,active_status, contains_full_genetic_sequences,sn_dataset_modality 
+RETURN 
 {
         rule_description:
         {       code:CodeRBD,application_context:context, name:NameRBD
         },
-        value:
-        {
-                assaytype:assaytype, dir_schema:dir_schema, tbl_schema:tbl_schema, vitessce_hints:vitessce_hints,
-                process_state:process_state,
-                pipeline_shorthand:pipeline_shorthand, description:description,
-                is_multiassay:is_multiassay, must_contain:must_contain,
-                active_status:active_status,
-                dataset_type:dataset_type_summary,
-                sennet_dataset_modalities: CASE WHEN toUpper(context)="SENNET" THEN sn_dataset_modality ELSE [] END,
-                contains_full_genetic_sequences:contains_full_genetic_sequences
-        }
-}
+        value: apoc.map.merge({
+                        assaytype:assaytype,dir_schema:dir_schema,tbl_schema:tbl_schema,vitessce_hints:vitessce_hints,
+                        process_state:process_state,
+                        pipeline_shorthand:pipeline_shorthand,description:description,
+                        is_multiassay:is_multiassay,must_contain:must_contain,
+                        active_status:active_status,
+                        dataset_type:dataset_type_summary,
+                        contains_full_genetic_sequences:contains_full_genetic_sequences
+                },
+                CASE WHEN toUpper(context)="SENNET" THEN {dataset_modalities: sn_dataset_modality} ELSE {} END
+        )
+} 
 AS rule_based_dataset
 }
 WITH rule_based_dataset

--- a/src/hs_ontology_api/cypher/datasettypes.cypher
+++ b/src/hs_ontology_api/cypher/datasettypes.cypher
@@ -89,10 +89,8 @@ CALL
 WITH dataset_type,pdr_category,fig2_aggregated_assaytype,fig2_modality,fig2_category,assaytypes,is_externally_processed,
 sn_dataset_modality, context
 $epictype_filter
-RETURN
-{
+RETURN apoc.map.merge({
         dataset_type:dataset_type,
-        sennet_dataset_modalities:CASE WHEN context='SENNET' THEN sn_dataset_modality ELSE 'n/a' END,
         PDR_category:pdr_category,
         fig2:
         {
@@ -102,4 +100,5 @@ RETURN
         },
         assaytypes:assaytypes,
         is_externally_processed:is_externally_processed
-} AS dataset_types
+},
+CASE WHEN toUpper(context)="SENNET" THEN {dataset_modalities: sn_dataset_modality} ELSE {} END) AS dataset_types


### PR DESCRIPTION
Neo4j cypher query tweaks:
- Omit response attribute `dataset_modalities` for app contexts other than SenNet.
- Return `dataset_modalities` instead of `sennet_dataset_modalities` due to the above query update.

TODO:
- Rename `sennet_dataset_modalities` to `dataset_modalities` in SmartAPI yaml