### PR TITLE
Initial commit to move to api-base-image1.2.0 and Python3.13

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.13
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.13"
     - name: Upgrade Pip
       run: python -m pip install --upgrade pip
       working-directory: src

--- a/docker/docker-development.sh
+++ b/docker/docker-development.sh
@@ -69,7 +69,7 @@ else
     if [ "$1" = "check" ]; then
         # Bash array
         config_paths=(
-            '../src/instance/app.cfg'
+            '../src/hs_ontology_api/instance/app.cfg'
         )
 
         for pth in "${config_paths[@]}"; do
@@ -106,7 +106,7 @@ else
         cp ../VERSION ubkg-api
         cp ../BUILD ubkg-api
 
-        docker compose -f docker-compose.yml -f docker-compose.development.yml -p hs-ontology-api build
+        docker compose -f docker-compose.yml -f docker-compose.development.yml -p hs-ontology-api build --no-cache
     elif [ "$1" = "start" ]; then
         docker compose -f docker-compose.yml -f docker-compose.development.yml -p hs-ontology-api up -d
     elif [ "$1" = "stop" ]; then

--- a/docker/ubkg-api/Dockerfile
+++ b/docker/ubkg-api/Dockerfile
@@ -1,5 +1,5 @@
 # Parent image
-FROM hubmap/api-base-image:1.1.0
+FROM hubmap/api-base-image:1.2.0
 
 LABEL description="HuBMAP and SenNet Ontology API"
 
@@ -9,34 +9,61 @@ WORKDIR /usr/src/app
 # Copy from host to image
 COPY . .
 
-# http://nginx.org/en/linux_packages.html#RHEL-CentOS
-# Set up the yum repository to install the latest mainline version of Nginx
-RUN echo $'[nginx-mainline]\n\
-name=nginx mainline repo\n\
-baseurl=http://nginx.org/packages/mainline/centos/$releasever/$basearch/\n\
-gpgcheck=1\n\
-enabled=0\n\
-gpgkey=https://nginx.org/keys/nginx_signing.key\n\
-module_hotfixes=true\n'\
->> /etc/yum.repos.d/nginx.repo
+# Set up the repository file for the stable version of
+# nginx which dnf should use (in the legacy "yum" location.)
+RUN set -eux && \
+    cat <<'EOF' > /etc/yum.repos.d/nginx.repo
+[nginx-stable]
+name=nginx stable repo
+baseurl=http://nginx.org/packages/centos/$releasever/$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=https://nginx.org/keys/nginx_signing.key
+module_hotfixes=true
+EOF
 
-RUN yum install -y yum-utils && \
-    yum-config-manager --enable nginx-mainline && \
-    yum install -y nginx && \
-    rm /etc/nginx/conf.d/default.conf && \
-    mv nginx/nginx.conf /etc/nginx/nginx.conf && \
-    rm -rf nginx && \
-    pip install --upgrade pip -r src/requirements.txt && \
-    chmod +x start.sh && \
-    yum clean all
+# Reduce the number of layers in image by minimizing the number of separate RUN commands
+# 1 - Install the prerequisites
+# 2 - By default, the repository for stable nginx packages is used.
+# 3 - Install nginx (using the custom dnf/yum repo specified earlier)
+# 4 - Remove the default nginx config file
+# 5 - Overwrite the nginx.conf with ours to run nginx as non-root
+# 6 - Remove the nginx directory copied from host machine (nginx/conf.d gets mounted to the container)
+# 7 - Upgrade pip (the one installed in base image may be old) and install service requirements.txt packages
+# 8 - Make the start script executable
+# 9 - Clean the dnf/yum cache and other locations to reduce Docker Image layer size.
+# Assume the base image has upgraded dnf and installed its dnf-plugins-core
+ RUN dnf install --assumeyes nginx && \
+     # Push aside nginx default.conf files that may exist on the system
+     [ ! -f /etc/nginx/conf.d/default.conf ] || mv /etc/nginx/conf.d/default.conf /tmp/etc_nginx_conf.d_default.conf.ORIGINAL && \
+     [ ! -f /etc/nginx/nginx.conf ] || mv /etc/nginx/nginx.conf /tmp/etc_nginx_nginx.conf.ORIGINAL && \
+     # Install the nginx default.conf file just installed in WORKDIR
+     mv nginx/nginx.conf /etc/nginx/nginx.conf && \
+     # Clean up the nginx install directory in WORKDIR
+     [ ! -d nginx ] || mv nginx /tmp/nginx_from_WORKDIR && \
+     # Push aside the verification file from the base image which will
+     # no longer report correctly once uWSGI is started for the service.
+     [ ! -f /tmp/verify_uwsgi.sh ] || mv /tmp/verify_uwsgi.sh /tmp/verify_uwsgi.sh.ORIGINAL && \
+     # Install the requirements.txt file for the service
+     pip3.13 install --no-cache-dir --upgrade pip -r src/requirements.txt && \
+     # Make the script referenced in the CMD directive below executable.
+     chmod a+x start.sh && \
+     # Clean up artifacts to slim down this layer of the Docker Image
+     dnf clean all && \
+     rm -rf /var/cache/dnf \
+            /var/log/dnf \
+     	     /var/log/yum \
+     	     /root/.cache
 
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime.
 # EXPOSE does not make the ports of the container accessible to the host.
 EXPOSE 5000 8080
 
-# Set an entrypoint
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+# Set an entrypoint by moving the file copied into the WORKDIR to
+# the location referenced by the ENTRYPOINT directive below, and
+# make it executable.
+RUN mv entrypoint.sh /usr/local/bin/entrypoint.sh && \
+    chmod a+x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 

--- a/docker/ubkg-api/start.sh
+++ b/docker/ubkg-api/start.sh
@@ -5,4 +5,4 @@
 nginx -g 'daemon off;' &
 
 # Start uwsgi and keep it running in foreground
-uwsgi --ini /usr/src/app/src/uwsgi.ini
+/usr/local/python3.13/bin/uwsgi --ini /usr/src/app/src/uwsgi.ini

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,19 +3,19 @@ Flask==3.0.3
 #git+https://github.com/x-atlas-consortia/ubkg-api.git@dev-integrate
 ubkg-api==2.2.3
 
+# Stick with Neo4j package version compatible with ubkg-api rather
+# than jumping to 5.26.0 or higher with Python 3.13 usage.
 neo4j==5.15.0
 
 # for analysis of tabular data
-pandas==1.5.0
-numpy==1.23.5
+pandas==2.3.0
+numpy==2.1.0
 
 # Cells API client
 # hubmap-api-py-client==0.0.9
 
 # Test and analysis scripts
-argparse==1.4.0
-datatest==0.11.1
-
+datatest==0.11.1 # tested on Python 2.6, 2.7, 3.2 through 3.10 as of 1/12/2026, per https://pypi.org/project/datatest/
 
 # for S3 worker
 boto3==1.36.17


### PR DESCRIPTION
Initial commit to move to api-base-image1.2.0 and Python3.13.

N.B. not every package version chosen for `requirements.txt` is indicated as Python 3.13 compatible at PyPi e.g. [https://pypi.org/project/neo4j/5.15.0/ ](https://pypi.org/project/neo4j/5.15.0/ )vs [https://pypi.org/project/neo4j/5.26.0/](https://pypi.org/project/neo4j/5.26.0/).  Versions selected for compatibility with existing dependencies, with an expectation to upgrade together.

Despite that, testing verifies expected results.