### PR TITLE
Bump ubkg-api version to 2.3.2

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 Flask==3.1.3
 
 #git+https://github.com/x-atlas-consortia/ubkg-api.git@dev-integrate
-ubkg-api==2.3.1
+ubkg-api==2.3.2
 
 # Stick with Neo4j package version compatible with ubkg-api rather
 # than jumping to 5.26.0 or higher with Python 3.13 usage.


### PR DESCRIPTION
Updated ubkg-api version from 2.3.1 to 2.3.2.