### PR TITLE
field-entities endpoint architecture now streams direct JSON response instead of using OpenAPI class

### DIFF
--- a/src/hs_ontology_api/cypher/fieldentities.cypher
+++ b/src/hs_ontology_api/cypher/fieldentities.cypher
@@ -1,80 +1,137 @@
 // Obtains entities associated with fields.
 // Replaces field_entities.yaml.
+// HMFIELD represents field mappings prior to the deployment of the CEDAR metadata manager.
 
-// The query result has the following format for the entities column:
-// HMFIELD|<Code in HMFIELD>|<term in HMFIELD>;HUBMAP|<Code in HUBMAP>|<term in HUMBMAP>, etc.
-// i.e.,
-// 1. The comma delimits the entities associated with a field.
-// 2. The semicolon delimits the entities by ontology (i.e., HMFIELD or HUBMAP).
-// 3. The pipe delimits the properties for an entity in an ontology for an entity.
-// example for a field that maps to both the "sample" and "dataset" entities.
-// ["HMFIELD|3004|sample;HUBMAP|C040002|Sample", "HMFIELD|3001|dataset;HUBMAP|C040001|Dataset"]
+// Optional filters:
+// $mapping_source_filter - filter on mapping source (HMFIELD or CEDAR)
+WITH $source_filter AS source_filter,
 
-/// Identify all metadata fields, from both:
-// - legacy sources (the field_*.yaml files in ingest-validation-tools, and modeled in HMFIELD), child codes of HMFIELD:1000
-// - current sources (CEDAR tempates, modeled in CEDAR), child codes of CEDAR:TemplateField
+// $field_filter - name of field on which to filter
+$field_filter AS field_filter,
 
-// Collect the HMFIELD and CEDAR codes for each metadata field to flatten to level of field name.
+// $entity_filter - name of entity on which to filter
+$entity_filter AS entity_filter,
 
-// The field_entities_get_logic in neo4j_logic will replace variables that start with the dollar sign.
+// $application_filter - name of application context (HUBMAP or SENNET)
+$application_filter AS application_filter
 
-// source_filter allows filtering by mapping source (HMFIELD or CEDAR).
-// field_filter allows filtering by field name.
+// First, find identifiers for fields. Fields are defined in both HMFIELD and CEDAR hierarchies.
 
-WITH $source_filter AS source_filter
-CALL
-{
-     MATCH (cFieldParent:Code)<-[:CODE]-(pFieldParent:Concept)-[:inverse_isa]->(pField:Concept)-[:CODE]->(cField:Code)-[rField:PT]->(tField:Term)
-     WHERE rField.CUI=pField.CUI
-     AND cFieldParent.CodeID IN ['HMFIELD:1000','CEDAR:TemplateField']
-     $field_filter
-     RETURN tField.name AS field_name,
-     apoc.text.join(COLLECT(DISTINCT cField.CodeID),'|') AS code_ids,
-     pField.CUI AS CUIField
-}
+WITH
+  source_filter,
+  field_filter,
+  entity_filter,
+  application_filter
+MATCH (cFieldParent:Code)<-[:CODE]-(pFieldParent:Concept)-[:inverse_isa]->
+(pField:Concept)-[:CODE]->(cField:Code)-[rField:PT {CUI:pField.CUI}]->(tField:Term)
+WHERE cFieldParent.CodeID IN ['HMFIELD:1000','CEDAR:TemplateField']
+AND CASE WHEN field_filter = "" THEN 1=1 ELSE tField.name=field_filter END
+
 // For each field, get associated provenance entities.
 // entity_filter allows filtering for provenance entity by name--e.g., "dataset", "Dataset".
 // application_filter allows filtering on application context--i.e., "HUBMAP" or "SENNET".
 
+WITH
+  source_filter,
+  entity_filter,
+  application_filter,
+  tField.name AS field_name,
+  COLLECT(DISTINCT cField.CodeID) AS field_code_ids,
+  pField.CUI AS CUIField
+  ORDER BY tField.name
+
 CALL
 {
-    // Each HMFIELD field node is linked to a HMFIELD entity node.
-    WITH CUIField,source_filter
-    OPTIONAL MATCH (pField:Concept)-[:used_in_entity]->(pEntity:Concept)-[:CODE]->(cEntity:Code)-[r:PT]->(tEntity:Term)
-    WHERE pField.CUI=CUIField
-    AND cEntity.SAB ='HMFIELD'
-    AND r.CUI=pEntity.CUI
-    $entity_filter
-    RETURN DISTINCT CASE WHEN source_filter IN ['HMFIELD',''] THEN REPLACE(cEntity.CodeID,':','|') + '|' + tEntity.name ELSE '' END AS entity
+    // 1. Each HMFIELD field node is linked to a HMFIELD entity node.
+    // For UNION symmetry, filter to the HMFIELD source.
+    WITH
+      CUIField,
+      source_filter,
+      entity_filter,
+      application_filter,
+      field_name,
+      field_code_ids
+
+    MATCH
+      (pField:Concept {CUI:CUIField})-[:used_in_entity]->
+      (pEntity:Concept)-[:CODE]->(cEntity:Code)-[r:PT {CUI:pEntity.CUI}]->
+      (tEntity:Term)
+    WHERE cEntity.SAB ='HMFIELD'
+    AND CASE
+      WHEN entity_filter= ""
+      THEN 1=1
+      ELSE tEntity.name=entity_filter
+    END
+    RETURN
+      {code:cEntity.CodeID,
+      name:tEntity.name,
+      source:'HMFIELD'} AS entity
 
     UNION
 
-    // Each HMFIELD entity node is cross-referenced to HUBMAP and SENNET provenance entity nodes.
-    WITH CUIField,source_filter
-    OPTIONAL MATCH (pField:Concept)-[:used_in_entity]->(pEntity:Concept)-[:CODE]->(cEntity:Code)-[r:PT]->(tEntity:Term)
-    WHERE pField.CUI=CUIField
-    $application_filter
-    AND r.CUI=pEntity.CUI
-    $entity_filter
-    RETURN DISTINCT CASE WHEN source_filter IN ['HMFIELD',''] THEN REPLACE(cEntity.CodeID,':','|') + '|' + tEntity.name ELSE '' END AS entity
+    //2. Each HMFIELD entity node is cross-referenced to HUBMAP and SENNET provenance entity nodes.
+
+    WITH
+      CUIField,
+      source_filter,
+      entity_filter,
+      application_filter,
+      field_name,
+      field_code_ids
+
+    MATCH
+      (pField:Concept {CUI:CUIField})-[:used_in_entity]->
+      (pEntity:Concept)-[:CODE]->(cEntity:Code)-[r:PT {CUI:pEntity.CUI}]->
+      (tEntity:Term)
+    WHERE CASE
+      WHEN application_filter = ""
+      THEN cEntity.SAB in ['HUBMAP','SENNET']
+      ELSE cEntity.SAB IN [application_filter]
+    END
+    AND CASE
+      WHEN entity_filter= ""
+      THEN 1=1
+      ELSE tEntity.name=entity_filter
+    END
+    RETURN
+      {code:cEntity.CodeID,
+      name:tEntity.name,
+      source:'HMFIELD'} AS entity
 
     UNION
 
-    //CEDAR template nodes are mapped to provenance entity nodes in both HUBMAP and SENNET.
-    //CEDAR field nodes relate to CEDAR template nodes.
+    //3. CEDAR template nodes are mapped to provenance entity nodes in both HUBMAP and SENNET.
+    //   CEDAR field nodes relate to CEDAR template nodes.
 
-    WITH CUIField,source_filter
-    OPTIONAL MATCH (pField:Concept)-[:inverse_has_field]->(pTemplate:Concept)-[:used_in_entity]->(pEntity:Concept)-[:CODE]->(cEntity:Code)-[r:PT]->(tEntity:Term)
-    WHERE pField.CUI = CUIField
-    AND r.CUI=pEntity.CUI
-    //AND c.Entity.SAB in ['HUBMAP','SENNET']
-    $application_filter
-    $entity_filter
-    RETURN DISTINCT CASE WHEN source_filter IN ['CEDAR',''] THEN REPLACE(cEntity.CodeID,':','|') + '|' + tEntity.name ELSE '' END AS entity
+    WITH
+      CUIField,
+      source_filter,
+      entity_filter,
+      application_filter,
+      field_name,
+      field_code_ids
+
+    MATCH
+      (pField:Concept {CUI:CUIField})-[:inverse_has_field]->
+      (pTemplate:Concept)-[:used_in_entity]->(pEntity:Concept)-[:CODE]->
+      (cEntity:Code)-[r:PT{CUI:pEntity.CUI}]->(tEntity:Term)
+    WHERE
+      CASE
+        WHEN application_filter = ""
+        THEN cEntity.SAB IN ['HUBMAP','SENNET']
+        ELSE cEntity.SAB IN [application_filter]
+    END
+    AND
+      CASE
+        WHEN entity_filter= ""
+        THEN 1=1
+        ELSE tEntity.name=entity_filter
+      END
+    RETURN
+      {code:cEntity.CodeID,
+      name:tEntity.name,
+      source:'CEDAR'} AS entity
 }
 
-WITH field_name, code_ids, entity
-WHERE entity <>""
-WITH field_name, code_ids, COLLECT(entity) AS entities
-RETURN field_name, code_ids, entities
-ORDER BY field_name
+WITH field_name, field_code_ids, COLLECT(entity) as entities
+RETURN {name:field_name, code_ids:field_code_ids, entities:{nodes:entities}} AS field_entity

--- a/src/hs_ontology_api/cypher/fieldentities_OLD.cypher
+++ b/src/hs_ontology_api/cypher/fieldentities_OLD.cypher
@@ -1,0 +1,90 @@
+// Obtains entities associated with fields.
+// Replaces field_entities.yaml.
+
+// The query result has the following format for the entities column:
+// HMFIELD|<Code in HMFIELD>|<term in HMFIELD>;HUBMAP|<Code in HUBMAP>|<term in HUMBMAP>, etc.
+// i.e.,
+// 1. The comma delimits the entities associated with a field.
+// 2. The semicolon delimits the entities by ontology (i.e., HMFIELD or HUBMAP).
+// 3. The pipe delimits the properties for an entity in an ontology for an entity.
+// example for a field that maps to both the "sample" and "dataset" entities.
+// ["HMFIELD|3004|sample;HUBMAP|C040002|Sample", "HMFIELD|3001|dataset;HUBMAP|C040001|Dataset"]
+
+/// Identify all metadata fields, from both:
+// - legacy sources (the field_*.yaml files in ingest-validation-tools, and modeled in HMFIELD), child codes of HMFIELD:1000
+// - current sources (CEDAR tempates, modeled in CEDAR), child codes of CEDAR:TemplateField
+
+// Collect the HMFIELD and CEDAR codes for each metadata field to flatten to level of field name.
+
+// The field_entities_get_logic in neo4j_logic will replace variables that start with the dollar sign.
+
+// source_filter allows filtering by mapping source (HMFIELD or CEDAR).
+// field_filter allows filtering by field name.
+
+WITH $source_filter AS source_filter,
+$field_filter AS field_filter,
+$entity_filter AS entity_filter,
+$application_filter AS application_filter
+CALL
+{
+     MATCH (cFieldParent:Code)<-[:CODE]-(pFieldParent:Concept)-[:inverse_isa]->(pField:Concept)-[:CODE]->(cField:Code)-[rField:PT {CUI:pField.CUI}]->(tField:Term)
+     WHERE cFieldParent.CodeID IN ['HMFIELD:1000','CEDAR:TemplateField']
+     AND CASE WHEN field_filter = "" THEN 1=1 ELSE tField.name=field_filter END
+     //$field_filter
+     RETURN tField.name AS field_name,
+     apoc.text.join(COLLECT(DISTINCT cField.CodeID),'|') AS code_ids,
+     pField.CUI AS CUIField
+}
+// For each field, get associated provenance entities.
+// entity_filter allows filtering for provenance entity by name--e.g., "dataset", "Dataset".
+// application_filter allows filtering on application context--i.e., "HUBMAP" or "SENNET".
+
+CALL
+{
+    // Each HMFIELD field node is linked to a HMFIELD entity node.
+    WITH CUIField,source_filter, entity_filter, application_filter
+    OPTIONAL MATCH
+      (pField:Concept {CUI:CUIField})-[:used_in_entity]->
+      (pEntity:Concept)-[:CODE]->(cEntity:Code)-[r:PT {CUI:pEntity.CUI}]->
+      (tEntity:Term)
+    WHERE cEntity.SAB ='HMFIELD'
+    //$entity_filter
+    AND CASE WHEN entity_filter= "" THEN 1=1 ELSE tEntity.name=entity_filter END
+    RETURN DISTINCT CASE WHEN source_filter IN ['HMFIELD',''] THEN REPLACE(cEntity.CodeID,':','|') + '|' + tEntity.name ELSE '' END AS entity
+
+    UNION
+
+    // Each HMFIELD entity node is cross-referenced to HUBMAP and SENNET provenance entity nodes.
+    WITH CUIField,source_filter, entity_filter, application_filter
+    OPTIONAL MATCH
+      (pField:Concept {CUI:CUIField})-[:used_in_entity]->
+      (pEntity:Concept)-[:CODE]->(cEntity:Code)-[r:PT{CUI:pEntity.CUI}]->
+      (tEntity:Term)
+    //$application_filter
+    WHERE CASE WHEN application_filter = "" THEN 1=1 ELSE cEntity.SAB IN [application_filter] END
+    //$entity_filter
+    AND CASE WHEN entity_filter= "" THEN 1=1 ELSE tEntity.name=entity_filter END
+    RETURN DISTINCT CASE WHEN source_filter IN ['HMFIELD',''] THEN REPLACE(cEntity.CodeID,':','|') + '|' + tEntity.name ELSE '' END AS entity
+
+    UNION
+
+    //CEDAR template nodes are mapped to provenance entity nodes in both HUBMAP and SENNET.
+    //CEDAR field nodes relate to CEDAR template nodes.
+
+    WITH CUIField,source_filter, entity_filter, application_filter
+    OPTIONAL MATCH
+      (pField:Concept {CUI:CUIField})-[:inverse_has_field]->
+      (pTemplate:Concept)-[:used_in_entity]->(pEntity:Concept)-[:CODE]->
+      (cEntity:Code)-[r:PT{CUI:pEntity.CUI}]->(tEntity:Term)
+    //$application_filter
+        WHERE CASE WHEN application_filter = "" THEN 1=1 ELSE cEntity.SAB IN [application_filter] END
+    //$entity_filter
+      AND CASE WHEN entity_filter= "" THEN 1=1 ELSE tEntity.name=entity_filter END
+    RETURN DISTINCT CASE WHEN source_filter IN ['CEDAR',''] THEN REPLACE(cEntity.CodeID,':','|') + '|' + tEntity.name ELSE '' END AS entity
+}
+
+WITH field_name, code_ids, entity
+WHERE entity <>""
+WITH field_name, code_ids, COLLECT(entity) AS entities
+RETURN field_name, code_ids, entities
+ORDER BY field_name

--- a/src/hs_ontology_api/routes/fieldentities/fieldentities_controller.py
+++ b/src/hs_ontology_api/routes/fieldentities/fieldentities_controller.py
@@ -25,14 +25,14 @@ def field_entities_get(name=None):
     if err != 'ok':
         return make_response(err, 400)
 
-    # Validate mapping source.
+    # Validate parameters with values from limited set.
     source = request.args.get('source')
     if source is not None:
         source = source.upper()
-        val_enum = ['HMFIELD', 'CEDAR']
-        err = validate_parameter_value_in_enum(param_name='source', param_value=source, enum_list=val_enum)
-        if err != 'ok':
-            return make_response(err, 400)
+    val_enum = ['HMFIELD', 'CEDAR']
+    err = validate_parameter_value_in_enum(param_name='source', param_value=source, enum_list=val_enum)
+    if err != 'ok':
+        return make_response(err, 400)
 
     # Validate application context.
     application = request.args.get('application_context')
@@ -55,7 +55,6 @@ def field_entities_get(name=None):
             err['message'] = err['message'] + ' Call field-types-info for a list of available field data types.'
         return make_response(err, 404)
 
-    # March 2025
     # Redirect to S3 if payload is large.
     return redirect_if_large(resp=result)
 

--- a/src/hs_ontology_api/utils/neo4j_logic.py
+++ b/src/hs_ontology_api/utils/neo4j_logic.py
@@ -1440,7 +1440,7 @@ def field_schemas_get_logic(neo4j_instance, field_name=None, mapping_source=None
         return fieldschemas
 
 
-def field_entities_get_logic(neo4j_instance, field_name=None, source=None, entity=None, application=None) -> List[FieldEntity]:
+def field_entities_get_logic(neo4j_instance, field_name=None, source=None, entity=None, application=None) -> List[dict]:
     """
     Returns detailed information on an ingest metadata field's associated entities.
 
@@ -1453,10 +1453,7 @@ def field_entities_get_logic(neo4j_instance, field_name=None, source=None, entit
     :param application: application context--i.e., HUBMAP or SENNET
     """
     # response list
-    fieldentities: [FieldEntity] = []
-
-    # Used in WHERE clauses when no filter is needed.
-    identity_filter = '1=1'
+    field_entities=[]
 
     # Load annotated Cypher query from the cypher directory.
     # The query is parameterized with variable $ids.
@@ -1465,10 +1462,8 @@ def field_entities_get_logic(neo4j_instance, field_name=None, source=None, entit
 
     # Allow for filtering on field name.
     if field_name is None:
-        field_filter = f' AND {identity_filter}'
-    else:
-        field_filter = f" AND tField.name = '{field_name}'"
-    querytxt = querytxt.replace('$field_filter', field_filter)
+        field_name =''
+    querytxt = querytxt.replace('$field_filter', f'"{field_name}"')
 
     # Allow for filtering on source.
     if source is None:
@@ -1479,21 +1474,19 @@ def field_entities_get_logic(neo4j_instance, field_name=None, source=None, entit
         source_filter = "''"
     querytxt = querytxt.replace('$source_filter', source_filter)
 
-    # Allow for filtering on entity.
     if entity is None:
-        entity_filter = f"AND {identity_filter}"
+        entity_filter = "''"
     else:
-        entity_filter = f"AND (tEntity.name='{entity}' OR tEntity.name='{entity}')"
+        entity_filter = f"'{entity}'"
     querytxt = querytxt.replace('$entity_filter', entity_filter)
 
     # Allow for filtering on application context.
     if application is None:
-        application_filter = f"AND cEntity.SAB IN ['HUBMAP','SENNET']"
+        application_filter = "''"
     else:
-        application_filter = f"AND cEntity.SAB='{application}'"
+        application_filter = f"'{application}'"
     querytxt = querytxt.replace('$application_filter', application_filter)
 
-    # March 2025
     # Set timeout for query based on value in app.cfg.
     query = neo4j.Query(text=querytxt, timeout=neo4j_instance.timeout)
 
@@ -1501,18 +1494,14 @@ def field_entities_get_logic(neo4j_instance, field_name=None, source=None, entit
         # Execute Cypher query.
         try:
             recds: neo4j.Result = session.run(query)
-            record_count = 0
 
+            record_count = 0
             # Build response object.
             for record in recds:
                 try:
-                    fieldentity: FieldEntity = FieldEntity(code_ids=record.get('code_ids'),
-                                                           name=record.get('field_name'),
-                                                           entities=record.get('entities')).serialize()
-
-                    fieldentities.append(fieldentity)
+                    field_entity = record.get('field_entity')
+                    field_entities.append(field_entity)
                     record_count = record_count + 1
-
                 except KeyError:
                     pass
 
@@ -1521,7 +1510,7 @@ def field_entities_get_logic(neo4j_instance, field_name=None, source=None, entit
             if e.code == 'Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration':
                 raise GatewayTimeout
 
-        return fieldentities
+        return field_entities
 
 def assayclasses_get_logic(neo4j_instance,assayclass=None, assaytype=None, process_state=None,
                            context=None, provide_hierarchy_info=None) -> dict:

--- a/src/hs_ontology_api/utils/neo4j_logic.py
+++ b/src/hs_ontology_api/utils/neo4j_logic.py
@@ -19,7 +19,6 @@ from hs_ontology_api.models.celltypelist_detail import CelltypesListDetail
 
 from hs_ontology_api.models.fieldassay import FieldAssay
 from hs_ontology_api.models.fieldschema import FieldSchema
-from hs_ontology_api.models.fieldentity import FieldEntity
 
 # Mar 2025
 # Until the ubkg-api is refactored so that format_list_for_query function is in


### PR DESCRIPTION
field-entities endpoint refactored to stream JSON instead of using OpenAPI classes. The refactored endpoint differs from the current production in that the nodes array is properly a key of the entities object.

This endpoint was originally for a beta Data Portal search UI feature to determine which fields to make available for a given entity search page.